### PR TITLE
Adding ttpSessionId instead of sessionId as key for keyStore

### DIFF
--- a/app/uk/gov/hmrc/selfservicetimetopay/auth/SAAuthentication.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/auth/SAAuthentication.scala
@@ -28,7 +28,7 @@ object SaGovernmentGateway extends GovernmentGateway {
 
   override def loginURL: String = SsttpFrontendConfig.loginUrl
 
-  override def sessionKeysToKeep = Seq("ttpSessionId")
+  override def sessionKeysToKeep = Seq(SsttpFrontendConfig.ttpSessionId)
 }
 
 object SaRegime extends TaxRegime {

--- a/app/uk/gov/hmrc/selfservicetimetopay/config/ssttpFrontendConfig.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/config/ssttpFrontendConfig.scala
@@ -44,4 +44,5 @@ object SsttpFrontendConfig extends AppConfig with ServicesConfig {
   private lazy val companyAuthSignInPath = getConfString("company-auth.sign-in-path", "")
   lazy val loginUrl: String = s"$companyAuthFrontend$companyAuthSignInPath"
   lazy val loginCallbackBaseUrl = getConfString("auth.login-callback.base-url", "")
+  lazy val ttpSessionId = "ttpSessionId"
 }

--- a/app/uk/gov/hmrc/selfservicetimetopay/util/SessionIdHelper.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/util/SessionIdHelper.scala
@@ -19,26 +19,25 @@ package uk.gov.hmrc.selfservicetimetopay.util
 import java.util.UUID
 
 import play.api.mvc._
-import uk.gov.hmrc.play.http.SessionKeys
+import uk.gov.hmrc.selfservicetimetopay.config.SsttpFrontendConfig
+import uk.gov.hmrc.selfservicetimetopay.config.SsttpFrontendConfig.ttpSessionId
 import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 
 import scala.concurrent.Future
 
 trait SessionProvider {
-  def createSessionId() = SessionKeys.sessionId -> s"session-${UUID.randomUUID}"
+  def createTtpSessionId() = ttpSessionId -> s"ttp-session-${UUID.randomUUID}"
 }
 
-trait CheckSessionAction extends ActionBuilder[Request] with ActionFilter[Request] with SessionProvider {
-  sessionProvider: SessionProvider =>
+trait CheckSessionAction extends ActionBuilder[Request] with ActionFilter[Request] {
+  val sessionProvider: SessionProvider
 
-  protected lazy val redirectTo = Results.Redirect(routes.SelfServiceTimeToPayController.start())
+  protected lazy val redirectToStartPage = Results.Redirect(routes.SelfServiceTimeToPayController.start())
 
   def filter[A](request: Request[A]): Future[Option[Result]] = {
-    Future.successful(request.session.get(SessionKeys.sessionId).fold[Option[Result]]
-      (Some(redirectTo.withNewSession.withSession(sessionProvider.createSessionId())))
+    Future.successful(request.session.get(ttpSessionId).fold[Option[Result]]
+      (Some(redirectToStartPage.withNewSession.withSession(sessionProvider.createTtpSessionId())))
       { _ => None }
     )
   }
 }
-
-object CheckSessionAction extends CheckSessionAction

--- a/test/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorControllerSpec.scala
@@ -56,7 +56,7 @@ class CalculatorControllerSpec extends UnitSpec with MockitoSugar with ScalaFutu
         .thenReturn(Future.successful(Some(ttpSubmissionNLI)))
 
       val result = await(controller.getCalculateInstalments(Some(3)).apply(FakeRequest()
-        .withSession(sessionProvider.createSessionId())))
+        .withSession(sessionProvider.createTtpSessionId())))
 
       status(result) shouldBe Status.OK
       verify(mockSessionCache, times(1)).get(Matchers.any(), Matchers.any())
@@ -69,7 +69,7 @@ class CalculatorControllerSpec extends UnitSpec with MockitoSugar with ScalaFutu
         .thenReturn(Future.successful(Some(ttpSubmissionNLINoSchedule)))
 
       val result = await(controller.getCalculateInstalments(Some(3)).apply(FakeRequest()
-        .withSession(sessionProvider.createSessionId())))
+        .withSession(sessionProvider.createTtpSessionId())))
 
       status(result) shouldBe Status.NOT_FOUND
     }
@@ -81,7 +81,7 @@ class CalculatorControllerSpec extends UnitSpec with MockitoSugar with ScalaFutu
         .thenReturn(Future.successful(Some(ttpSubmissionNLIEmpty)))
 
       val result = await(controller.submitPaymentToday().apply(FakeRequest()
-        .withSession(sessionProvider.createSessionId())))
+        .withSession(sessionProvider.createTtpSessionId())))
 
       status(result) shouldBe Status.SEE_OTHER
     }
@@ -94,7 +94,7 @@ class CalculatorControllerSpec extends UnitSpec with MockitoSugar with ScalaFutu
         .thenReturn(Future.successful(Some(ttpSubmissionNLIOver10k)))
 
       val result = await(controller.submitCalculateInstalmentsPaymentToday().apply(FakeRequest()
-        .withSession(sessionProvider.createSessionId())))
+        .withSession(sessionProvider.createTtpSessionId())))
 
       status(result) shouldBe Status.SEE_OTHER
     }
@@ -110,7 +110,7 @@ class CalculatorControllerSpec extends UnitSpec with MockitoSugar with ScalaFutu
 
       val result = await(controller.submitCalculateInstalmentsPaymentToday().apply(FakeRequest()
         .withFormUrlEncodedBody("amount" -> "200")
-        .withSession(sessionProvider.createSessionId())))
+        .withSession(sessionProvider.createTtpSessionId())))
 
       status(result) shouldBe Status.SEE_OTHER
     }

--- a/test/uk/gov/hmrc/selfservicetimetopay/controllers/DirectDebitControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfservicetimetopay/controllers/DirectDebitControllerSpec.scala
@@ -64,7 +64,7 @@ class DirectDebitControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "successfully display the direct debit form page" in {
-      val response = await(controller.getDirectDebit(FakeRequest().withSession(sessionProvider.createSessionId())))
+      val response = await(controller.getDirectDebit(FakeRequest().withSession(sessionProvider.createTtpSessionId())))
 
       status(response) shouldBe OK
 
@@ -80,7 +80,7 @@ class DirectDebitControllerSpec extends UnitSpec with MockitoSugar with WithFake
       when(mockSessionCache.get(Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some(ttpSubmission)))
       when(mockSessionCache.put(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(mock[CacheMap]))
 
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(validDirectDebitForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(validDirectDebitForm: _*)
 
       val response = await(controller.submitDirectDebit(request))
 
@@ -98,7 +98,7 @@ class DirectDebitControllerSpec extends UnitSpec with MockitoSugar with WithFake
       when(mockSessionCache.get(Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some(ttpSubmission)))
       when(mockSessionCache.put(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(mock[CacheMap]))
 
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(invalidBankDetailsForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(invalidBankDetailsForm: _*)
 
       val response = await(controller.submitDirectDebit(request))
 
@@ -108,7 +108,7 @@ class DirectDebitControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit direct debit form with invalid form data and return a bad request" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(inValidDirectDebitForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(inValidDirectDebitForm: _*)
 
       val response = await(controller.submitDirectDebit(request))
 
@@ -132,7 +132,7 @@ class DirectDebitControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "successfully display the direct debit confirmation page" in {
-      val response = await(controller.getDirectDebitConfirmation(FakeRequest().withSession(sessionProvider.createSessionId())))
+      val response = await(controller.getDirectDebitConfirmation(FakeRequest().withSession(sessionProvider.createTtpSessionId())))
 
       status(response) shouldBe OK
 

--- a/test/uk/gov/hmrc/selfservicetimetopay/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfservicetimetopay/controllers/EligibilityControllerSpec.scala
@@ -71,7 +71,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
       when(mockSessionCache.get(Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some(ttpSubmission)))
       when(mockSessionCache.put(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(mock[CacheMap]))
 
-      val response: Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val response: Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(response) shouldBe SEE_OTHER
 
@@ -79,7 +79,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "successfully display the type of tax page" in {
-      val response: Result = controller.getTypeOfTax.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val response: Result = controller.getTypeOfTax.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(response) shouldBe OK
 
@@ -87,7 +87,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "successfully display the existing ttp page" in {
-      val response = await(controller.getExistingTtp.apply(FakeRequest().withSession(sessionProvider.createSessionId())))
+      val response = await(controller.getExistingTtp.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId())))
 
       status(response) shouldBe OK
 
@@ -95,7 +95,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit type of tax given valid data and redirect to existing ttp page" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(typeOfTaxForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(typeOfTaxForm: _*)
 
       val response: Future[Result] = await(controller.submitTypeOfTax.apply(request))
 
@@ -105,7 +105,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit type of tax given both types of tax and redirect to call us page" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(bothTypeOfTaxForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(bothTypeOfTaxForm: _*)
 
       val response: Future[Result] = await(controller.submitTypeOfTax.apply(request))
 
@@ -115,7 +115,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit type of tax given other types of tax and redirect to call us page" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId()).withFormUrlEncodedBody(otherTaxForm: _*)
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId()).withFormUrlEncodedBody(otherTaxForm: _*)
 
       val response: Future[Result] = await(controller.submitTypeOfTax.apply(request))
 
@@ -125,7 +125,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit existing ttp given no existing ttp data and redirect to amount you owe page" in {
-      val request = FakeRequest().withFormUrlEncodedBody(falseExistingTtpForm: _*).withSession(sessionProvider.createSessionId())
+      val request = FakeRequest().withFormUrlEncodedBody(falseExistingTtpForm: _*).withSession(sessionProvider.createTtpSessionId())
 
       val response: Future[Result] = await(controller.submitExistingTtp.apply(request))
 
@@ -136,7 +136,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "submit existing ttp given existing ttp data and redirect to call us page" in {
-      val request = FakeRequest().withFormUrlEncodedBody(trueExistingTtpForm: _*).withSession(sessionProvider.createSessionId())
+      val request = FakeRequest().withFormUrlEncodedBody(trueExistingTtpForm: _*).withSession(sessionProvider.createTtpSessionId())
 
       val response: Future[Result] = await(controller.submitExistingTtp.apply(request))
 
@@ -146,7 +146,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "redirect to self on type of tax page and display errors when invalid data is submitted" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId())
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId())
 
       val response: Future[Result] = await(controller.submitTypeOfTax.apply(request))
 
@@ -154,7 +154,7 @@ class EligibilityControllerSpec extends UnitSpec with MockitoSugar with WithFake
     }
 
     "redirect to self on existing ttp page and display errors when invalid data is submitted" in {
-      val request = FakeRequest().withSession(sessionProvider.createSessionId())
+      val request = FakeRequest().withSession(sessionProvider.createTtpSessionId())
 
       val response: Future[Result] = await(controller.submitExistingTtp.apply(request))
 

--- a/test/uk/gov/hmrc/selfservicetimetopay/controllers/SelfServiceTimeToPayControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfservicetimetopay/controllers/SelfServiceTimeToPayControllerSpec.scala
@@ -34,7 +34,7 @@ class SelfServiceTimeToPayControllerSpec extends UnitSpec with MockitoSugar with
     val controller = new SelfServiceTimeToPayController()
 
     "return 200 and display the service start page" in {
-      val result:Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val result:Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(result) shouldBe OK
 
@@ -42,7 +42,7 @@ class SelfServiceTimeToPayControllerSpec extends UnitSpec with MockitoSugar with
     }
 
     "redirect to the eligibility section if user selects start" in {
-      val result:Result = controller.submit.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val result:Result = controller.submit.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(result) shouldBe SEE_OTHER
 
@@ -50,7 +50,7 @@ class SelfServiceTimeToPayControllerSpec extends UnitSpec with MockitoSugar with
     }
 
     "return 200 and display call us page successfully" in {
-      val result:Result = controller.getTtpCallUs.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val result:Result = controller.getTtpCallUs.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(result) shouldBe OK
 
@@ -58,7 +58,7 @@ class SelfServiceTimeToPayControllerSpec extends UnitSpec with MockitoSugar with
     }
 
     "return 200 and display you need to file page successfully" in {
-      val result: Result = controller.getYouNeedToFile.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val result: Result = controller.getYouNeedToFile.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(result) shouldBe OK
 

--- a/test/uk/gov/hmrc/selfservicetimetopay/controllers/calculator/AmountsDueControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfservicetimetopay/controllers/calculator/AmountsDueControllerSpec.scala
@@ -58,7 +58,7 @@ class AmountsDueControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
       when(mockSessionCache.get(Matchers.any(), Matchers.any())).thenReturn(Future.successful(Some(ttpSubmission)))
       when(mockSessionCache.put(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(mock[CacheMap]))
 
-      val response: Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val response: Result = controller.start.apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(response) shouldBe SEE_OTHER
 
@@ -66,7 +66,7 @@ class AmountsDueControllerSpec extends UnitSpec with MockitoSugar with WithFakeA
     }
 
     "successfully display the amounts you owe page" in {
-      val response: Result = controller.getAmountsDue().apply(FakeRequest().withSession(sessionProvider.createSessionId()))
+      val response: Result = controller.getAmountsDue().apply(FakeRequest().withSession(sessionProvider.createTtpSessionId()))
 
       status(response) shouldBe OK
 


### PR DESCRIPTION
Mapping in explicitly within header carrier for passing to KeyStore.