### PR TITLE
Adding beta banner

### DIFF
--- a/app/uk/gov/hmrc/selfservicetimetopay/config/ssttpFrontendConfig.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/config/ssttpFrontendConfig.scala
@@ -25,6 +25,9 @@ trait AppConfig {
   val analyticsHost: String
   val reportAProblemPartialUrl: String
   val reportAProblemNonJSUrl: String
+  val betaFeedbackUrlNoAuth :String
+  val betaFeedbackUrlAuth :String
+
 }
 
 object SsttpFrontendConfig extends AppConfig with ServicesConfig {
@@ -39,6 +42,8 @@ object SsttpFrontendConfig extends AppConfig with ServicesConfig {
   override lazy val analyticsHost = loadConfig("google-analytics.host")
   override lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   override lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
+  override lazy val betaFeedbackUrlNoAuth = s"$contactHost/contact/beta-feedback-unauthenticated?service=$contactFormServiceIdentifier"
+  override lazy val betaFeedbackUrlAuth = s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier"
 
   private lazy val companyAuthFrontend = getConfString("company-auth.url", throw new RuntimeException("Company auth url required"))
   private lazy val companyAuthSignInPath = getConfString("company-auth.sign-in-path", "")

--- a/app/views/selfservicetimetopay/govuk_wrapper.scala.html
+++ b/app/views/selfservicetimetopay/govuk_wrapper.scala.html
@@ -10,7 +10,8 @@
         serviceInfoContent: Html = HtmlFormat.empty,
         scriptElem: Option[Html] = None,
         linksElem: Option[Html] = None,
-        noGetHelp:Boolean = false)(implicit request: Request[_])
+        noGetHelp:Boolean = false,
+        loggedIn:Boolean = false)(implicit request: Request[_])
 
 @import layouts.{govuk_template => hmrcGovUkTemplate}
 @import uk.gov.hmrc.play.views.html.{helpers => uiHelpers, layouts => uiLayouts}
@@ -49,7 +50,7 @@
 
 @serviceInfo = {
 @uiLayouts.serviceInfo(
-    betaBanner = uiLayouts.betaBanner(false, appConfig.betaFeedbackUrlAuth, appConfig.betaFeedbackUrlNoAuth, true),
+    betaBanner = uiLayouts.betaBanner(loggedIn, appConfig.betaFeedbackUrlAuth, appConfig.betaFeedbackUrlNoAuth, true),
     includeGridWrapper = false,
     serviceInfoContent = Some(serviceInfoContent)
 )

--- a/app/views/selfservicetimetopay/govuk_wrapper.scala.html
+++ b/app/views/selfservicetimetopay/govuk_wrapper.scala.html
@@ -49,8 +49,7 @@
 
 @serviceInfo = {
 @uiLayouts.serviceInfo(
-    betaBanner = HtmlFormat.empty,
-    //betaBanner = uiLayouts.betaBanner(false, "contact/beta-feedback?service=SSTTP", "contact/beta-feedback-unauthenticated?service=SSTTP", true),
+    betaBanner = uiLayouts.betaBanner(false, appConfig.betaFeedbackUrlAuth, appConfig.betaFeedbackUrlNoAuth, true),
     includeGridWrapper = false,
     serviceInfoContent = Some(serviceInfoContent)
 )

--- a/app/views/selfservicetimetopay/main.scala.html
+++ b/app/views/selfservicetimetopay/main.scala.html
@@ -33,5 +33,6 @@
     mainContent = layouts.article(mainContent),
     scriptElem = Some(scriptElems),
     linksElem = linksElem,
-    noGetHelp = noGetHelp
+    noGetHelp = noGetHelp,
+    loggedIn = loggedIn
 )


### PR DESCRIPTION
Adds beta banner with form submission via contact-frontend - this needs to be tested in all environments.

![beta-banner](https://cloud.githubusercontent.com/assets/275315/21188973/fc80db4c-c214-11e6-8a73-bf45ab9891e8.png)
