### PR TITLE
Adding breakdown to auth calcualtor page

### DIFF
--- a/app/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorController.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorController.scala
@@ -140,7 +140,7 @@ class CalculatorController(calculatorConnector: CalculatorConnector) extends Tim
 
   def submitCalculateInstalments: Action[AnyContent] = Action.async { implicit request =>
     sessionCache.get.flatMap[Result] {
-      case Some(ttpSubmission@TTPSubmission(Some(schedule), _, _, taxpayer@Some(_), Some(_), _, cd@CalculatorInput(debits, paymentToday, _, _, _, _), _)) =>
+      case Some(ttpSubmission@TTPSubmission(Some(schedule), _, _, taxpayer:Option[Taxpayer], Some(_), _, cd@CalculatorInput(debits, paymentToday, _, _, _, _), _)) =>
         val form = CalculatorForm.createPaymentTodayForm(debits.map(_.amount).sum).fill(paymentToday)
         CalculatorForm.durationForm.bindFromRequest().fold(
           formWithErrors => Future.successful(BadRequest(calculate_instalments_form(schedule, taxpayer match {
@@ -158,7 +158,7 @@ class CalculatorController(calculatorConnector: CalculatorConnector) extends Tim
 
   def submitCalculateInstalmentsPaymentToday: Action[AnyContent] = Action.async { implicit request =>
     sessionCache.get.flatMap[Result] {
-      case Some(ttpData@TTPSubmission(Some(schedule), _, _, taxpayer@Some(_), _, _, cd, _)) =>
+      case Some(ttpData@TTPSubmission(Some(schedule), _, _, taxpayer:Option[Taxpayer], _, _, cd, _)) =>
         val durationForm = CalculatorForm.durationForm.fill(CalculatorDuration(3))
         CalculatorForm.createPaymentTodayForm(cd.debits.map(_.amount).sum).bindFromRequest().fold(
           formWithErrors => Future.successful(BadRequest(calculate_instalments_form(schedule, taxpayer match {

--- a/app/views/selfservicetimetopay/calculator/calculate_instalments_form.scala.html
+++ b/app/views/selfservicetimetopay/calculator/calculate_instalments_form.scala.html
@@ -3,15 +3,17 @@
 
     @param schedule The PaymentSchedule to show
     @param monthOptions List of number of months available to pay over
-    @param auth Boolean set to true if the user is authenticated, default false
+    @param debits Option[Seq[Debit]] list of tax debits from the user's SA account
+    @param loggedIn Boolean set to true if the user is authenticated, default false
 *@
+@import uk.gov.hmrc.selfservicetimetopay.models.Debit
 @import uk.gov.hmrc.selfservicetimetopay.models.CalculatorDuration
 @import uk.gov.hmrc.selfservicetimetopay.models.CalculatorPaymentSchedule
-@import uk.gov.hmrc.selfservicetimetopay.controllers.CalculatorController
-@(schedule:CalculatorPaymentSchedule, durationForm:Form[CalculatorDuration], paymentTodayAmountForm: Form[BigDecimal], monthOptions:Seq[Int], loggedIn: Boolean)(implicit request: Request[_])
+@import play.twirl.api.HtmlFormat
+@(schedule:CalculatorPaymentSchedule, debits:Option[Seq[Debit]], durationForm:Form[CalculatorDuration], paymentTodayAmountForm: Form[BigDecimal], monthOptions:Seq[Int], loggedIn: Boolean)(implicit request: Request[_])
 @import selfservicetimetopay.helpers.{message_list, pluralize, labelWrap}
 @import selfservicetimetopay.helpers.forms.{form, formErrorSummary, button, fieldErrors, numberinput, inlinecurrencyinput}
-@import selfservicetimetopay.partials.currency
+@import selfservicetimetopay.partials.{currency, what_you_owe}
 @import selfservicetimetopay.calculator.{calculate_instalments_auth_footer, calculate_instalments_no_auth_footer}
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @selfservicetimetopay.main(
@@ -27,7 +29,17 @@
     <section>
         <h2>@Messages("ssttp.calculator.results.heading.what-you-owe")</h2>
         <div class="subsection grid-layout divider--bottom">
-            <div class="grid-layout__column grid-layout__column--2-3">@Messages("ssttp.calculator.results.you-owe")</div>
+            <div class="grid-layout__column grid-layout__column--2-3">@Messages("ssttp.calculator.results.you-owe")
+            @debits match {
+                case Some(debits: Seq[Debit]) => {
+                    <details class="trackedDetails" id="calculatorWhatYouOweBreakdown">
+                        <summary class="font-xsmall">@Messages("ssttp.calculator.results.you-owe.breakdown")</summary>
+                        @what_you_owe(debits, true)
+                    </details>
+                }
+                case _ => {}
+            }
+            </div>
             <div class="grid-layout__column grid-layout__column--1-3">@currency(schedule.amountToPay)</div>
         </div>
         <div class="subsection divider--bottom grid-layout">

--- a/app/views/selfservicetimetopay/calculator/calculate_instalments_print.scala.html
+++ b/app/views/selfservicetimetopay/calculator/calculate_instalments_print.scala.html
@@ -2,14 +2,14 @@
     Time To Pay Payment Schedule Calculator Page Print version
 
     @param schedule The PaymentSchedule to show
-    @param monthOptions List of number of months available to pay over
-    @param auth Boolean set to true if the user is authenticated, default false
-    @param whitelist Boolean set to true if the user is whitelisted to access this service, default false
+    @param debits Option[Seq[Debit]] list of tax debits from the user's SA account
+    @param loggedIn Boolean set to true if the user is authenticated, default false
 *@
 @import uk.gov.hmrc.selfservicetimetopay.models.CalculatorPaymentSchedule
-@(schedule:CalculatorPaymentSchedule, loggedIn:Boolean = false)(implicit request: Request[_])
+@import uk.gov.hmrc.selfservicetimetopay.models.Debit
+@(schedule:CalculatorPaymentSchedule, debits:Option[Seq[Debit]], loggedIn:Boolean = false)(implicit request: Request[_])
 @import selfservicetimetopay.helpers.{message_list, pluralize}
-@import selfservicetimetopay.partials.currency
+@import selfservicetimetopay.partials.{currency, what_you_owe}
 @import selfservicetimetopay.calculator.{calculate_instalments_auth_footer, calculate_instalments_no_auth_footer}
 @script = {
     <script type="text/javascript">$(function(){window.print()})</script>
@@ -26,7 +26,17 @@
     <section>
         <h2>@Messages("ssttp.calculator.results.heading.what-you-owe")</h2>
         <div class="subsection grid-layout divider--bottom">
-            <div class="grid-layout__column grid-layout__column--2-3">@Messages("ssttp.calculator.results.you-owe")</div>
+            <div class="grid-layout__column grid-layout__column--2-3">@Messages("ssttp.calculator.results.you-owe")
+            @debits match {
+                case Some(debits: Seq[Debit]) => {
+                    <details class="trackedDetails" id="calculatorWhatYouOweBreakdown" open>
+                        <summary class="font-xsmall">@Messages("ssttp.calculator.results.you-owe.breakdown")</summary>
+                        @what_you_owe(debits, true)
+                    </details>
+                }
+                case _ => {}
+            }
+            </div>
             <div class="grid-layout__column grid-layout__column--1-3 text--right no-wrap">@currency(schedule.amountToPay)</div>
         </div>
         <div class="subsection divider--bottom grid-layout">

--- a/app/views/selfservicetimetopay/partials/what_you_owe.scala.html
+++ b/app/views/selfservicetimetopay/partials/what_you_owe.scala.html
@@ -1,27 +1,30 @@
 @*
     Partial view to show list of what a user owes having validated against their account
+
+    @param debits Seq[Debit] list of tax debits to showd
+    @param smallFormat Boolean, default false, apply the small font modifier to this list to show within another element
 *@
 @import uk.gov.hmrc.selfservicetimetopay.models.Debit
-@(debits:Seq[Debit])
+@(debits:Seq[Debit], smallFormat:Boolean = false)
 @import java.time.format.DateTimeFormatter
 @import selfservicetimetopay.partials.{currency, charge_code}
 @import java.util.Locale
 @defining(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH)) { formatter =>
-    <div class="subsection grid-layout divider--bottom font-xsmall">
+    <div class="@if(!smallFormat){subsection}else{grid-layout--no-gutter} grid-layout divider--bottom font-xsmall">
         <div class="grid-layout__column grid-layout__column--3-4"><strong>@Messages("ssttp.amounts_due.due")</strong></div>
         <div class="grid-layout__column grid-layout__column--1-4"><strong>@Messages("ssttp.amounts_due.amount")</strong></div>
     </div>
     @debits.map { debit =>
-        <div class="subsection grid-layout divider--bottom font-xsmall">
+        <div class="@if(!smallFormat){subsection}else{grid-layout--no-gutter} grid-layout font-xsmall@if(!smallFormat){ divider--bottom}">
             <div class="grid-layout__column grid-layout__column--3-4">
-                <div><span class="font-small">@debit.dueDate.format(formatter)</span></div>
+                <div><span class="@if(smallFormat){font-xxsmall}else{font-small}">@debit.dueDate.format(formatter)</span></div>
                 <small>@{debit.originCode match {
                     case Some(code:String) => <span class="font-xsmall">{charge_code(code, debit.taxYearEnd)}</span>
                     case _ =>
                 }}</small>
             </div>
             <div class="grid-layout__column grid-layout__column--1-4 align--middle">
-                <p class="font-small">@currency(debit.amount)</p>
+                <p><span class="@if(smallFormat){font-xxsmall}else{font-small}">@currency(debit.amount)</span></p>
             </div>
         </div>
     }

--- a/conf/messages
+++ b/conf/messages
@@ -168,6 +168,7 @@ ssttp.calculator.results.title=Calculate your instalments
 
 ssttp.calculator.results.heading.what-you-owe=What you owe
 ssttp.calculator.results.you-owe=You owe a total of:
+ssttp.calculator.results.you-owe.breakdown=View breakdown
 ssttp.calculator.results.you-can-afford=You can afford to pay:
 ssttp.calculator.results.your-instalment-balance=Your balance for instalments:
 ssttp.calculator.results.heading.choose-your-instalments=Select how many months you need


### PR DESCRIPTION
I have updated as per below, screenshots and pdf print views.

![animation](https://cloud.githubusercontent.com/assets/275315/21391426/a07a21ae-c783-11e6-95bf-2d1310cfd9d5.gif)

[auth-print.pdf](https://github.com/hmrc/self-service-time-to-pay-frontend/files/666462/auth-print.pdf)

[no-auth-print.pdf](https://github.com/hmrc/self-service-time-to-pay-frontend/files/666463/no-auth-print.pdf)
