### PR TITLE
SSTTP-955 Correct heading h2/h1 tags and styles

### DIFF
--- a/app/views/selfservicetimetopay/arrangement/account_not_found.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/account_not_found.scala.html
@@ -16,12 +16,12 @@ Time To Pay Bank account not found - select existing direct debit or create new 
             bankAccounts.map{ b => (b.referenceNumber.get, b.accountNumber.get + " | " + b.sortCode.get) }
 }
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.arrangement.misalignment.title"),
     loggedIn = loggedIn,
     sidebarLinks = Some(having_problems_sidebar())
 ){
     <header class="page-header text">
-        <h2>@Messages("ssttp.arrangement.misalignment.title")</h2>
+        <h1>@Messages("ssttp.arrangement.misalignment.title")</h1>
     </header>
         @highlight('_modifierClass -> "highlight-message--light"){<p>@Messages("ssttp.arrangement.misalignment.subtitle")</p>}
         @form(routes.DirectDebitController.submitBankAccountNotFound()) {

--- a/app/views/selfservicetimetopay/arrangement/application_complete.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/application_complete.scala.html
@@ -14,13 +14,9 @@
 @import selfservicetimetopay.helpers.message_list
 @import selfservicetimetopay.partials.{what_you_owe, direct_debit_details, payment_schedule}
 @import selfservicetimetopay.partials.currency
-@printCssLink = {
-  <link rel='stylesheet' href='@routes.Assets.at("css/self-service-time-to-pay.css")' />
-}
 
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
-  linksElem = Some(printCssLink),
+  title = Messages("ssttp.arrangement.complete.title"),
   loggedIn = loggedIn,
   sidebarLinks = Some(selfservicetimetopay.partials.help_and_advice_sidebar())
 ){

--- a/app/views/selfservicetimetopay/arrangement/direct_debit_assistance.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/direct_debit_assistance.scala.html
@@ -13,7 +13,7 @@
 @import selfservicetimetopay.partials.{what_you_owe, currency}
 
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
+  title = Messages("ssttp.arrangement.direct-debit.assistance.title"),
   loggedIn = loggedIn
 ){
   @if(showErrorNotification) {
@@ -25,7 +25,7 @@
       </div>
   }
   <header class="page-header text">
-    <h2>@Messages("ssttp.arrangement.direct-debit.assistance.title")</h2>
+    <h1>@Messages("ssttp.arrangement.direct-debit.assistance.title")</h1>
   </header>
 
   <section>

--- a/app/views/selfservicetimetopay/arrangement/direct_debit_confirmation.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/direct_debit_confirmation.scala.html
@@ -15,10 +15,12 @@ Time To Pay Direct Debit Conformation Display Page
 @import selfservicetimetopay.partials.{direct_debit_details, payment_schedule, direct_debit_guarantee}
 
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.arrangement.direct-debit.confirmation.title"),
     loggedIn = loggedIn
 ){
-    <h1>@Messages("ssttp.arrangement.direct-debit.confirmation.title")</h1>
+    <header class="page-header text">
+        <h1>@Messages("ssttp.arrangement.direct-debit.confirmation.title")</h1>
+    </header>
     <section>
         @direct_debit_details(directDebit)
         <div class="subsection">

--- a/app/views/selfservicetimetopay/arrangement/direct_debit_form.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/direct_debit_form.scala.html
@@ -13,12 +13,12 @@ Time To Pay Direct Debit Form Page
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
+  title = Messages("ssttp.arrangement.direct-debit.form.title"),
   loggedIn = loggedIn,
   sidebarLinks = Some(having_problems_sidebar())
 ){
     <header class="page-header text">
-        <h2>@Messages("ssttp.arrangement.direct-debit.form.title")</h2>
+        <h1>@Messages("ssttp.arrangement.direct-debit.form.title")</h1>
     </header>
       @form(routes.DirectDebitController.submitDirectDebit()) {
       @formErrorSummary(Messages("ssttp.arrangement.direct-debit.form.error.summary.title"), ddForm, Seq.empty)

--- a/app/views/selfservicetimetopay/arrangement/instalment_plan_summary.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/instalment_plan_summary.scala.html
@@ -17,12 +17,12 @@ Time To Pay Instalment Summary Pretty Print Page
     @import selfservicetimetopay.helpers.forms.{form, inlinetextinput, submit}
     @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
     @selfservicetimetopay.main(
-        title = Messages("ssttp.common.title"),
+        title = Messages("ssttp.arrangement.instalment-summary.title"),
         loggedIn = signedIn
     ) {
     <a href="javascript:window.print()" class="js-visible no-print float--right gutter-left print-link js-visible trackedPrintLink">@Messages("ssttp.arrangement.instalment-summary.print")</a>
        <header class="page-header text">
-            <h2>@Messages("ssttp.arrangement.instalment-summary.title")</h2>
+            <h1>@Messages("ssttp.arrangement.instalment-summary.title")</h1>
         </header>
         <section class="section">
             <div class="subsection grid-layout">

--- a/app/views/selfservicetimetopay/arrangement/print_schedule_summary.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/print_schedule_summary.scala.html
@@ -8,10 +8,12 @@ Time To Pay Instalment Summary Display Page
 @(schedule:CalculatorPaymentSchedule)(implicit request: Request[_])
 @import selfservicetimetopay.helpers.{highlight, alert, message_list}
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
+  title = Messages("ssttp.arrangement.instalment-summary.title"),
   bodyClasses = None
 ){
-    <h1 style="heading-h1">@Messages("ssttp.arrangement.instalment-summary.title")</h1>
+    <header class="page-header text">
+        <h1>@Messages("ssttp.arrangement.instalment-summary.title")</h1>
+    </header>
     <section class="section">
         <div class="subsection grid-layout">
             <div class="grid-layout__column grid-layout__column--1-2">

--- a/app/views/selfservicetimetopay/calculator/amounts_due_form.scala.html
+++ b/app/views/selfservicetimetopay/calculator/amounts_due_form.scala.html
@@ -27,7 +27,7 @@
     })
 ){
     <header class="page-header text">
-        <h1 class="heading-h1">@Messages("ssttp.calculator.form.amounts_due.title")</h1>
+        <h1>@Messages("ssttp.calculator.form.amounts_due.title")</h1>
     </header>
     @formErrorSummary(Messages("ssttp.calculator.form.amounts_due.error.summary.title"), dataForm, Seq.empty)
     <p>@Messages("ssttp.calculator.form.amounts_due.intro")</p>

--- a/app/views/selfservicetimetopay/calculator/calculate_instalments_form.scala.html
+++ b/app/views/selfservicetimetopay/calculator/calculate_instalments_form.scala.html
@@ -17,12 +17,12 @@
 @import selfservicetimetopay.calculator.{calculate_instalments_auth_footer, calculate_instalments_no_auth_footer}
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.calculator.results.title"),
     loggedIn = loggedIn
 ){
     <a target="_blank" href="@routes.CalculatorController.getCalculateInstalmentsPrint()" class="float--right gutter-left print-link print-hidden js-visible trackedPrintLink">@Messages("ssttp.arrangement.instalment-summary.print")</a>
     <header class="page-header text">
-        <h2>@Messages("ssttp.calculator.results.title")</h2>
+        <h1>@Messages("ssttp.calculator.results.title")</h1>
     </header>
     @formErrorSummary(Messages("ssttp.error.summary.title"), paymentTodayAmountForm, Seq.empty)
     @formErrorSummary(Messages("ssttp.error.summary.title"), durationForm, Seq.empty)

--- a/app/views/selfservicetimetopay/calculator/calculate_instalments_print.scala.html
+++ b/app/views/selfservicetimetopay/calculator/calculate_instalments_print.scala.html
@@ -15,14 +15,16 @@
     <script type="text/javascript">$(function(){window.print()})</script>
 }
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.calculator.results.title"),
     mainClass = Some("hard--bottom"),
     bodyClasses = None,
     scriptElem = Some(script),
     noGetHelp = true,
     loggedIn = loggedIn
 ){
-    <h1>@Messages("ssttp.calculator.results.title")</h1>
+    <header class="page-header text">
+        <h1>@Messages("ssttp.calculator.results.title")</h1>
+    </header>
     <section>
         <h2>@Messages("ssttp.calculator.results.heading.what-you-owe")</h2>
         <div class="subsection grid-layout divider--bottom">

--- a/app/views/selfservicetimetopay/calculator/misalignment.scala.html
+++ b/app/views/selfservicetimetopay/calculator/misalignment.scala.html
@@ -11,11 +11,11 @@ Amounts Due Misalignment page - designed to be shown when the debts a user enter
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.calculator.misalignment-page.title"),
     loggedIn = loggedIn
 ){
     <header class="page-header text">
-        <h2 class="h1-heading">@Messages("ssttp.calculator.misalignment-page.title")</h2>
+        <h1>@Messages("ssttp.calculator.misalignment-page.title")</h1>
     </header>
     @highlight('_modifierClass  -> "highlight-message--light"){
         <p>@Messages("ssttp.calculator.misalignment-page.subtitle")</p>

--- a/app/views/selfservicetimetopay/calculator/payment_today_form.scala.html
+++ b/app/views/selfservicetimetopay/calculator/payment_today_form.scala.html
@@ -8,11 +8,11 @@
 @import selfservicetimetopay.helpers.forms.{currencyinput, form, formErrorSummary, submit}
 @import uk.gov.hmrc.selfservicetimetopay.controllers._
 @selfservicetimetopay.main(
-  title = Messages("ssttp.common.title"),
+  title = Messages("ssttp.calculator.form.payment_today.title"),
   loggedIn = loggedIn
 ){
   <header class="page-header text">
-    <h2 class="h1-heading">@Messages("ssttp.calculator.form.payment_today.title")</h2>
+    <h1>@Messages("ssttp.calculator.form.payment_today.title")</h1>
   </header>
   @form(routes.CalculatorController.submitPaymentToday(), 'class -> "group") {
     @formErrorSummary(Messages("ssttp.calculator.form.payment_today.error.summary.title"), dataForm, Seq.empty)

--- a/app/views/selfservicetimetopay/core/call_us.scala.html
+++ b/app/views/selfservicetimetopay/core/call_us.scala.html
@@ -4,11 +4,11 @@
 @(loggedIn: Boolean = false)(implicit request: Request[_])
 @import selfservicetimetopay.helpers.message_list
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.call-us.title"),
     loggedIn = loggedIn
 ){
     <header class="page-header text">
-        <h2>@Messages("ssttp.call-us.title")</h2>
+        <h1>@Messages("ssttp.call-us.title")</h1>
     </header>
     <p class="subsection">@Messages("ssttp.call-us.intro")</p>
     <p class="subsection">

--- a/app/views/selfservicetimetopay/core/service_start.scala.html
+++ b/app/views/selfservicetimetopay/core/service_start.scala.html
@@ -3,7 +3,7 @@
 @import selfservicetimetopay.helpers.forms.{form, submit}
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.landing.title"),
     loggedIn = loggedIn
 ){
     <header class="page-header text">

--- a/app/views/selfservicetimetopay/core/unavailable.scala.html
+++ b/app/views/selfservicetimetopay/core/unavailable.scala.html
@@ -3,11 +3,11 @@ Self-service Time To Pay service unavailable page to redirect users to the call-
 *@
 @(loggedIn: Boolean = false)(implicit request: Request[_])
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.unavailable.title"),
     loggedIn = loggedIn
 ) {
     <header class="page-header text">
-        <h2>@Messages("ssttp.unavailable.title")</h2>
+        <h1>@Messages("ssttp.unavailable.title")</h1>
     </header>
     <p>@Messages("ssttp.unavailable.intro")</p>
     <p>@Messages("ssttp.unavailable.instructions")</p>

--- a/app/views/selfservicetimetopay/core/you_need_to_file.scala.html
+++ b/app/views/selfservicetimetopay/core/you_need_to_file.scala.html
@@ -2,11 +2,11 @@
 @import selfservicetimetopay.helpers.{highlight, message_list}
 
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.you-need-to-file.title"),
     loggedIn = signedIn
 ){
     <header class="page-header text">
-        <h2 class="h1-heading">@Messages("ssttp.you-need-to-file.title")</h2>
+        <h1>@Messages("ssttp.you-need-to-file.title")</h1>
     </header>
     <section class="section  divider--bottom">
         @highlight('_modifierClass -> "highlight-message--light") {

--- a/app/views/selfservicetimetopay/eligibility/existing_ttp.scala.html
+++ b/app/views/selfservicetimetopay/eligibility/existing_ttp.scala.html
@@ -3,11 +3,11 @@
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @import selfservicetimetopay.helpers.forms._
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.eligibility.form.existing_ttp.title"),
     loggedIn = loggedIn
 ) {
     <header class="page-header text">
-        <h2>@Messages("ssttp.eligibility.form.existing_ttp.title")</h2>
+        <h1>@Messages("ssttp.eligibility.form.existing_ttp.title")</h1>
     </header>
     @form(routes.EligibilityController.submitExistingTtp(), 'class -> "group") {
         @formErrorSummary(Messages("ssttp.eligibility.form.existing_ttp.error.summary.title"), dataForm, Seq.empty)

--- a/app/views/selfservicetimetopay/eligibility/type_of_tax_form.scala.html
+++ b/app/views/selfservicetimetopay/eligibility/type_of_tax_form.scala.html
@@ -6,11 +6,11 @@
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @import selfservicetimetopay.helpers.forms._
 @selfservicetimetopay.main(
-    title = Messages("ssttp.common.title"),
+    title = Messages("ssttp.eligibility.form.type_of_tax.title"),
     loggedIn = loggedIn
 ){
   <header class="page-header text">
-    <h2>@Messages("ssttp.eligibility.form.type_of_tax.title")</h2>
+    <h1>@Messages("ssttp.eligibility.form.type_of_tax.title")</h1>
   </header>
   @form(routes.EligibilityController.submitTypeOfTax(), 'class -> "group") {
     @formErrorSummary(Messages("ssttp.eligibility.form.type_of_tax.error.summary.title"), dataForm, Seq.empty)

--- a/app/views/selfservicetimetopay/main.scala.html
+++ b/app/views/selfservicetimetopay/main.scala.html
@@ -24,6 +24,12 @@
 }else{
     @HtmlFormat.empty
 }}
+@linksElems = {
+    @linksElem.getOrElse("")
+    <link rel='stylesheet' href='@routes.Assets.at("css/self-service-time-to-pay.css")' />
+}
+
+
 @govuk_wrapper(appConfig = uk.gov.hmrc.selfservicetimetopay.config.SsttpFrontendConfig,
     title = title,
     mainClass = mainClass,
@@ -33,7 +39,7 @@
     contentHeader = contentHeader,
     mainContent = layouts.article(mainContent),
     scriptElem = Some(scriptElems),
-    linksElem = linksElem,
+    linksElem = Some(linksElems),
     googleAnalyticsCalls = googleAnalyticsCalls,
     noGetHelp = noGetHelp,
     loggedIn = loggedIn

--- a/public/css/self-service-time-to-pay.css
+++ b/public/css/self-service-time-to-pay.css
@@ -1,3 +1,11 @@
+.page-header h1 {
+    font-size: 36px;
+}
+
+.page-header h1.h1-heading {
+    font-size: 48px;
+}
+
 .print-only{
     display: none;
 }


### PR DESCRIPTION
Update page titles to reflect the heading text.
Return heading text to h1 tags
Workaround CSS implementation for h1 tags within headings.

![image](https://cloud.githubusercontent.com/assets/275315/21693624/89adc5b4-d379-11e6-96be-580f7c1ac7f7.png)
