### PR TITLE
SSTTP-1162 - Wrong interest amount shown initially upon amending debts

### DIFF
--- a/app/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorController.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/controllers/CalculatorController.scala
@@ -168,8 +168,10 @@ class CalculatorController(calculatorConnector: CalculatorConnector) extends Tim
     val index = CalculatorForm.removeAmountDueForm.bindFromRequest()
     sessionCache.get.map {
       case Some(ttpSubmission@TTPSubmission(_, _, _, _, _, _, cd@CalculatorInput(debits, _, _, _, _, _), _, _, _)) =>
-        ttpSubmission.copy(calculatorData = cd.copy(debits = debits.patch(index.value.get, Nil, 1)))
-      case _ => TTPSubmission(calculatorData = CalculatorInput.initial.copy(debits = IndexedSeq.empty))
+        ttpSubmission.copy(calculatorData = cd.copy(debits = debits.patch(index.value.get, Nil, 1)),
+          schedule = None)
+      case _ => TTPSubmission(calculatorData = CalculatorInput.initial.copy(debits = IndexedSeq.empty),
+        schedule = None)
     }.flatMap[Result] {
       case data@TTPSubmission(_, _, _, _, `validTypeOfTax`, `validExistingTTP`,
       CalculatorInput(debits, _, _, _, _, _), _, _, _) if debits.isEmpty =>

--- a/app/views/selfservicetimetopay/calculator/what_you_owe_review.scala.html
+++ b/app/views/selfservicetimetopay/calculator/what_you_owe_review.scala.html
@@ -4,8 +4,8 @@ Entered what you owe review page
 *@
 
 @import uk.gov.hmrc.selfservicetimetopay.models.Debit
-@import selfservicetimetopay.partials.{payment_schedule_editable, gaDoCheckout}
-@import selfservicetimetopay.helpers.forms.{form , submit}
+@import selfservicetimetopay.partials.payment_schedule_editable
+@import selfservicetimetopay.helpers.forms.{form, submit}
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 
 @(debits:Seq[Debit])(implicit request: Request[_])


### PR DESCRIPTION
When an amount was being removed, the calculator input was being updated
in keystore but the schedule was not. As a result, when the calculator page
was loading, it was matching against Some(schedule) and loading the old data.
Now, when an amount is removed, schedule is set to None to force the calculator
to re-calculate when it initially loads.