### PR TITLE
SSTTP-1158 - Side bar not appearing on mobile pages

### DIFF
--- a/app/views/selfservicetimetopay/partials/having_problems_sidebar.scala.html
+++ b/app/views/selfservicetimetopay/partials/having_problems_sidebar.scala.html
@@ -1,7 +1,6 @@
 @import uk.gov.hmrc.selfservicetimetopay.controllers.routes
 @()
-@import uk.gov.hmrc.selfservicetimetopay.controllers.routes
-<div class="section--blue-top sidebar--hidden-sm">
+<div class="section--blue-top side-nav--mobile-visible">
     <h3 class="heading-small">@Messages("ssttp.sidebar.having_problems.title")</h3>
     <p class="font-xsmall">@Messages("ssttp.sidebar.having_problems.intro")</p>
     <nav class="service_info__navigation" role="navigation" aria-labelledby="parent-subsection">

--- a/app/views/selfservicetimetopay/partials/help_and_advice_sidebar.scala.html
+++ b/app/views/selfservicetimetopay/partials/help_and_advice_sidebar.scala.html
@@ -1,5 +1,5 @@
 @()
-<div class="section--blue-top sidebar--hidden-sm">
+<div class="section--blue-top side-nav--mobile-visible">
     <h3 class="heading-small">@Messages("ssttp.sidebar.help-and-advice.title")</h3>
     <nav class="service_info__navigation" role="navigation" aria-labelledby="parent-subsection">
         <ul>

--- a/app/views/selfservicetimetopay/partials/sign_in_sidebar.scala.html
+++ b/app/views/selfservicetimetopay/partials/sign_in_sidebar.scala.html
@@ -1,5 +1,5 @@
 @()@import uk.gov.hmrc.selfservicetimetopay.controllers.routes
-<div class="section--blue-top sidebar--hidden-sm">
+<div class="section--blue-top side-nav--mobile-visible">
     <h3 class="heading-small">@Messages("ssttp.sidebar.sign-in.title")</h3>
     <p class="font-xsmall">@Messages("ssttp.sidebar.sign-in.intro")</p>
     <nav class="service_info__navigation" role="navigation" aria-labelledby="parent-subsection">


### PR DESCRIPTION
Sidebars were set to hidden, for some reason, which meant they were not being displayed on mobile.
These have been updated to now be visible on mobile layout.