### PR TITLE
SSTTP-1153 - Update direct debit conf page to match v5 of the prototype

### DIFF
--- a/app/views/selfservicetimetopay/arrangement/direct_debit_confirmation.scala.html
+++ b/app/views/selfservicetimetopay/arrangement/direct_debit_confirmation.scala.html
@@ -6,14 +6,12 @@ Time To Pay Direct Debit Conformation Display Page
 
 *@
 @import uk.gov.hmrc.selfservicetimetopay.models.{CalculatorPaymentSchedule, ArrangementDirectDebit, Debit}
+@import selfservicetimetopay.helpers.forms.{form, submit}
+@import uk.gov.hmrc.selfservicetimetopay.controllers.routes
+@import selfservicetimetopay.partials.{direct_debit_details, payment_schedule, gaDoCheckout, currency}
+@import uk.gov.hmrc.play.config.AssetsConfig
 @(debits: Seq[Debit], schedule: CalculatorPaymentSchedule, directDebit: ArrangementDirectDebit, loggedIn: Boolean = false)(implicit messages: play.api.i18n.Messages, request: Request[_])
 
-@import selfservicetimetopay.helpers.{alert, message_list}
-@import selfservicetimetopay.helpers.forms.{form, submit}
-@import selfservicetimetopay.partials.currency
-@import uk.gov.hmrc.selfservicetimetopay.controllers.{routes => ssttpRoutes}
-@import selfservicetimetopay.partials.{direct_debit_details, payment_schedule, direct_debit_guarantee, gaDoCheckout}
-@import uk.gov.hmrc.play.config.AssetsConfig
 @gaCheckoutCode = {
 @gaDoCheckout(debits = debits,
     step = 3,
@@ -34,10 +32,10 @@ Time To Pay Direct Debit Conformation Display Page
     </header>
     <section>
         <h2>@Messages("ssttp.arrangement.direct-debit.confirmation.your-bank")</h2>
-        @direct_debit_details(directDebit)
+        <p>@direct_debit_details(directDebit)</p>
         <div class="subsection">
-            <h3>@Messages("ssttp.direct-debit.title")</h3>
-            @payment_schedule(schedule)
+            <h2>@Messages("ssttp.direct-debit.title")</h2>
+            <p>@payment_schedule(schedule)</p>
             <div class="subsection text--right">
                 @Messages("ssttp.arrangement.direct-debit.confirmation.total-payment")
                 <strong>@currency(schedule.totalPayable)</strong>
@@ -52,21 +50,21 @@ Time To Pay Direct Debit Conformation Display Page
                     <img src="@{AssetsConfig.assetsPrefix}/images/direct-debit-logo-2x.png" width="148px" height="60px">
                 </p>
                 <ul class="bullets">
-                    <li>@Messages("ssttp.direct-debit.guarantee.list.1")</li>
-                    <li>@Messages("ssttp.direct-debit.guarantee.list.2")</li>
-                    <li>@Messages("ssttp.direct-debit.guarantee.list.3")</li>
-                    <li>@Messages("ssttp.direct-debit.guarantee.list.4")</li>
-                    <li>@Messages("ssttp.direct-debit.guarantee.list.5")</li>
+                    <li class="font-xsmall">@Messages("ssttp.direct-debit.guarantee.list.1")</li>
+                    <li class="font-xsmall">@Messages("ssttp.direct-debit.guarantee.list.2")</li>
+                    <li class="font-xsmall">@Messages("ssttp.direct-debit.guarantee.list.3")</li>
+                    <li class="font-xsmall">@Messages("ssttp.direct-debit.guarantee.list.4")</li>
+                    <li class="font-xsmall">@Messages("ssttp.direct-debit.guarantee.list.5")</li>
                 </ul>
             </div>
         </details>
-        @form(ssttpRoutes.ArrangementController.submit(), 'class -> "group") {
+        @form(routes.ArrangementController.submit(), 'class -> "group") {
             @submit() {
                 @Messages("ssttp.arrangement.direct-debit.confirmation.confirm-payment")
             }
         }
         <div>&nbsp;</div>
-        <div><a class="back-link" href="@ssttpRoutes.DirectDebitController.getDirectDebit()">@Messages("ssttp.calculator.form.back")</a></div>
+        <div><a class="back-link" href="@routes.DirectDebitController.getDirectDebit()">@Messages("ssttp.calculator.form.back")</a></div>
     </section>
 }
 

--- a/app/views/selfservicetimetopay/partials/direct_debit_details.scala.html
+++ b/app/views/selfservicetimetopay/partials/direct_debit_details.scala.html
@@ -7,7 +7,7 @@
 @import uk.gov.hmrc.selfservicetimetopay.models.ArrangementDirectDebit
 @(directDebit:ArrangementDirectDebit, print:Boolean = false)(implicit messages: play.api.i18n.Messages)
 <div class="section">
-    <div class="subsection grid-layout divider--bottom font-xsmall">
+    <div class="subsection grid-layout grid-layout--no-gutter divider--bottom font-small ssttp-grid-layout-padding-above">
         <div class="grid-layout__column grid-layout__column--3-4">
             <strong>@Messages("ssttp.direct-debit.account-name")</strong>
         </div>
@@ -15,7 +15,7 @@
             @directDebit.accountName
         </div>
     </div>
-    <div class="subsection grid-layout divider--bottom font-xsmall">
+    <div class="subsection grid-layout grid-layout--no-gutter divider--bottom font-small ssttp-grid-layout-padding-above">
         <div class="grid-layout__column grid-layout__column--3-4">
             <strong>@Messages("ssttp.direct-debit.account-number")</strong>
         </div>
@@ -24,7 +24,7 @@
         </div>
     </div>
 
-    <div class="subsection grid-layout divider--bottom font-xsmall">
+    <div class="subsection grid-layout grid-layout--no-gutter divider--bottom font-small ssttp-grid-layout-padding-above">
         <div class="grid-layout__column grid-layout__column--3-4">
             <strong>@Messages("ssttp.direct-debit.sort-code")</strong>
         </div>

--- a/app/views/selfservicetimetopay/partials/payment_schedule.scala.html
+++ b/app/views/selfservicetimetopay/partials/payment_schedule.scala.html
@@ -10,7 +10,7 @@ Partial view to show list of direct debit payments in the payment schedule
 
 @defining(DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.ENGLISH)) { formatter =>
 @if(schedule.initialPayment > BigDecimal(0)) {
-<div class="subsection grid-layout divider--bottom font-xsmall">
+<div class="subsection grid-layout divider--bottom font-small">
     <div class="grid-layout__column grid-layout__column--3-4">
         <div><strong>@LocalDate.now.plusWeeks(1).format(formatter)</strong></div>
         <div>@Messages("ssttp.arrangement.instalment-summary.schedule.initial-payment")</div>
@@ -19,19 +19,19 @@ Partial view to show list of direct debit payments in the payment schedule
 </div>
 }
 @schedule.instalments.map { instalment =>
-<div class="subsection grid-layout divider--bottom font-xsmall">
+<div class="subsection grid-layout divider--bottom font-small">
     <p>
-    <div class="grid-layout__column grid-layout__column--3-4">
-        <div><strong>@instalment.paymentDate.format(formatter)</strong></div>
-        @if(instalment == schedule.instalments.last) {
-        <div>@Messages("ssttp.arrangement.instalment-summary.schedule.final-payment",
-            currency(schedule.totalInterestCharged))
+        <div class="grid-layout__column grid-layout__column--3-4">
+            <div><strong>@instalment.paymentDate.format(formatter)</strong></div>
+            @if(instalment == schedule.instalments.last) {
+            <div>@Messages("ssttp.arrangement.instalment-summary.schedule.final-payment",
+                currency(schedule.totalInterestCharged))
+            </div>
+            }
         </div>
-        }
-    </div>
     </p>
     <p>
-    <div class="grid-layout__column grid-layout__column--1-4">@currency(instalment.amount)</div>
+        <div class="grid-layout__column grid-layout__column--1-4">@currency(instalment.amount)</div>
     </p>
 </div>
 }

--- a/public/css/self-service-time-to-pay.css
+++ b/public/css/self-service-time-to-pay.css
@@ -24,3 +24,7 @@
         display: block;
     }
 }
+
+.ssttp-grid-layout-padding-above {
+    margin-top: -10px;
+}


### PR DESCRIPTION
Added custom css to remove the massive spacing added when using assets frontend grid layout.
Edited in-page header to be h2 rather than h3
Increased the text size of bank and payment plan details, whilst making direct debit
information smaller