### PR TITLE
Et ops 4285 redirect from tech difficulties to call us

### DIFF
--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -16,7 +16,6 @@
 
 import java.time.LocalDate
 
-import langswitch.Language
 import language.Dates
 import play.api.i18n.Messages
 import timetopaytaxpayer.cor.model.Debit
@@ -27,7 +26,8 @@ package object model {
 
   def asDebitInput(debit: Debit): DebitInput = DebitInput(
     debit.amount,
-    debit.dueDate
+    debit.getDueDate()
+
   )
 
   def asTaxpayersSaUtr(saUtr: SaUtr): timetopaytaxpayer.cor.model.SaUtr =
@@ -46,6 +46,6 @@ package object model {
   }
 
   implicit class DebitExt(val v: Debit) extends AnyVal {
-    def dueByYear(offset: Int = 0): Int = v.dueDate.getYear - offset
+    def dueByYear(offset: Int = 0): Int = v.getDueDate().getYear - offset
   }
 }

--- a/app/ssttpaccessibility/AccessibilityController.scala
+++ b/app/ssttpaccessibility/AccessibilityController.scala
@@ -45,7 +45,7 @@ class AccessibilityController @Inject() (
 
   import requestSupport._
 
-  def getAccessibilityStatement(): Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
+  def getAccessibilityStatement(): Action[AnyContent] = as.action.async { implicit request =>
     JourneyLogger.info(s"AccessibilityController.getAccessibilityStatement: $request")
     Future.successful(Ok(views.accessibility_statement()))
   }

--- a/app/ssttparrangement/ArrangementController.scala
+++ b/app/ssttparrangement/ArrangementController.scala
@@ -213,7 +213,8 @@ class ArrangementController @Inject() (
         eligibilityStatus.reasons.contains(OldDebtIsTooHigh) ||
         eligibilityStatus.reasons.contains(NoDebt) ||
         eligibilityStatus.reasons.contains(TTPIsLessThenTwoMonths) ||
-        eligibilityStatus.reasons.contains(NoDueDate)) notEligible
+        eligibilityStatus.reasons.contains(NoDueDate) ||
+        eligibilityStatus.reasons.contains(DebitHasNoRelevantDueDate)) notEligible
       else if (eligibilityStatus.reasons.contains(IsNotOnIa)) notOnIa
       else if (eligibilityStatus.reasons.contains(TotalDebtIsTooHigh)) overTenThousandOwed
       else if (eligibilityStatus.reasons.contains(ReturnNeedsSubmitting) || eligibilityStatus.reasons.contains(DebtIsInsignificant)) youNeedToFile

--- a/app/ssttparrangement/ArrangementController.scala
+++ b/app/ssttparrangement/ArrangementController.scala
@@ -241,7 +241,7 @@ class ArrangementController @Inject() (
 
       if (journey.status == Statuses.FinishedApplicationSuccessful) {
         Ok(views.application_complete(
-          debits        = journey.taxpayer.selfAssessment.debits.sortBy(_.dueDate.toEpochDay()),
+          debits        = journey.taxpayer.selfAssessment.debits.sortBy(_.getDueDate().toEpochDay()),
           transactionId = journey.taxpayer.selfAssessment.utr + LocalDateTime.now(clockProvider.getClock).toString,
           directDebit   = journey.arrangementDirectDebit.get,
           schedule      = journey.schedule.get.schedule,

--- a/app/ssttpcalculator/CalculatorService.scala
+++ b/app/ssttpcalculator/CalculatorService.scala
@@ -227,7 +227,7 @@ object CalculatorService {
         selfAssessment
           .debits
           .filter(_.amount > 32)
-          .map(_.dueDate)
+          .map(_.getDueDate())
           .min
           .plusYears(1)
       )

--- a/app/ssttpdirectdebit/DirectDebitController.scala
+++ b/app/ssttpdirectdebit/DirectDebitController.scala
@@ -73,7 +73,7 @@ class DirectDebitController @Inject() (
 
     submissionService.authorizedForSsttp {
       case Journey(_, Statuses.InProgress, _, _, Some(schedule), _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
-        Future.successful(Ok(views.direct_debit_assistance(sa.debits.sortBy(_.dueDate.toEpochDay()), schedule, isSignedIn)))
+        Future.successful(Ok(views.direct_debit_assistance(sa.debits.sortBy(_.getDueDate().toEpochDay()), schedule, isSignedIn)))
       case journey =>
         JourneyLogger.info("DirectDebitController.getDirectDebitAssistance: pattern match redirect on error", journey)
         Future.successful(technicalDifficulties(journey))
@@ -83,7 +83,7 @@ class DirectDebitController @Inject() (
   def getDirectDebitError: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     submissionService.authorizedForSsttp {
       case Journey(_, Statuses.InProgress, _, _, Some(schedule), _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
-        Future.successful(Ok(views.direct_debit_assistance(sa.debits.sortBy(_.dueDate.toEpochDay()), schedule, true, isSignedIn)))
+        Future.successful(Ok(views.direct_debit_assistance(sa.debits.sortBy(_.getDueDate().toEpochDay()), schedule, true, isSignedIn)))
       case journey =>
         JourneyLogger.info("DirectDebitController.getDirectDebitError - redirect on error", journey)
         Future.successful(technicalDifficulties(journey))

--- a/app/ssttpeligibility/EligibilityService.scala
+++ b/app/ssttpeligibility/EligibilityService.scala
@@ -74,17 +74,14 @@ object EligibilityService {
   // Charge - any money owed that less than 30 days overdue
   // Liability - any money that is not yet due
   private def checkDebits(debits: Seq[Debit], today: LocalDate): List[Reason] = {
-    //TODO this needs to do something along these lines but need to alter the model to make relevant due date an option
-    // may also have to ensure that the JSON reading/writing can handle it
     //If there are any debits without a relevantDueDate then we stop here
-    val debitsWithNoRelevantDueDate: Seq[Debit] = debits.filter(nextDebit => nextDebit.dueDate == None)
-    if (debitsWithNoRelevantDueDate.nonEmpty) List(DebitHasNoRelevantDueDate)
+    if (!debits.forall(_.dueDate.isDefined)) List(DebitHasNoRelevantDueDate)
 
     val chargeStartDay: LocalDate = today.minusDays(1)
     val dateBeforeWhichDebtIsConsideredOld: LocalDate = today.minusDays(numberOfDaysAfterDueDateForDebtToBeConsideredOld)
 
-    val (liabilities, chargesAndDebts) = debits.partition(_.dueDate.isAfter(chargeStartDay))
-    val debt = chargesAndDebts.filterNot(_.dueDate.isAfter(dateBeforeWhichDebtIsConsideredOld))
+    val (liabilities, chargesAndDebts) = debits.partition(_.getDueDate.isAfter(chargeStartDay))
+    val debt = chargesAndDebts.filterNot(_.getDueDate.isAfter(dateBeforeWhichDebtIsConsideredOld))
 
     val totalLiabilities = liabilities.map(l => getTotalForDebit(l)).sum
     val totalChargesAndDebt = chargesAndDebts.map(cd => getTotalForDebit(cd)).sum

--- a/app/ssttpeligibility/EligibilityService.scala
+++ b/app/ssttpeligibility/EligibilityService.scala
@@ -40,6 +40,12 @@ object EligibilityService {
   def runEligibilityCheck(eligibilityRequest: EligibilityRequest, onIa: Boolean): EligibilityStatus = {
     val selfAssessmentDetails: SelfAssessmentDetails = eligibilityRequest.taxpayer.selfAssessment
     val isOnIa: List[Reason] = if (onIa) Nil else List(IsNotOnIa)
+    //TODO this needs to do something along these lines but need to alter the model to make relevant due date an option
+    // may also have to ensure that the JSON reading/writing can handle it
+    val debitHasNoRelevantDueDate: Seq[Debit] = eligibilityRequest.taxpayer.selfAssessment.debits
+    val filteredList = debitHasNoRelevantDueDate.filter(x => x.dueDate == None)
+    if(filteredList.nonEmpty) Nil  //TODO this should be a list with the reason in it call it below
+
 
     val reasons = (checkReturnsUpToDate(selfAssessmentDetails.returns, eligibilityRequest.dateOfEligibilityCheck)
       ++ checkDebits(selfAssessmentDetails.debits, eligibilityRequest.dateOfEligibilityCheck) ++ isOnIa)

--- a/app/ssttpeligibility/IaService.scala
+++ b/app/ssttpeligibility/IaService.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class IaService @Inject() (http:           HttpClient,
                            servicesConfig: ServicesConfig) {
   private lazy val baseUrl: String = servicesConfig.baseUrl("ia")
-  val enableCheck = true
+  val enableCheck = false
 
   def checkIaUtr(utr: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Boolean] = {
     if (enableCheck) {
@@ -35,7 +35,7 @@ class IaService @Inject() (http:           HttpClient,
         case 204 => false
       })
     } else {
-      Future.successful(false)
+      Future.successful(true)
     }
   }
 }

--- a/app/ssttpeligibility/IaService.scala
+++ b/app/ssttpeligibility/IaService.scala
@@ -33,6 +33,7 @@ class IaService @Inject() (http:           HttpClient,
       http.GET(baseUrl + s"/ia/$utr").map(res => res.status match {
         case 200 => true
         case 204 => false
+        case _   => throw new RuntimeException("IA Service Failed To Respond As Expected")
       })
     } else {
       Future.successful(true)

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/EligibilityStatus.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/EligibilityStatus.scala
@@ -27,6 +27,7 @@ case object OldDebtIsTooHigh extends Reason("OldDebtIsTooHigh")
 case object TotalDebtIsTooHigh extends Reason("TotalDebtIsTooHigh")
 case object ReturnNeedsSubmitting extends Reason("ReturnNeedsSubmitting")
 case object IsNotOnIa extends Reason("IsNotOnIa")
+case object DebitHasNoRelevantDueDate extends Reason("DebitHasNoRelevantDueDate")
 //TODO the ones below are unused for now and apparently always have been
 case object TTPIsLessThenTwoMonths extends Reason("TTPIsLessThenTwoMonths")
 case object NotSaEnrolled extends Reason("NotEnrolled")

--- a/app/views/partials/tax_liabilities_summary.scala.html
+++ b/app/views/partials/tax_liabilities_summary.scala.html
@@ -25,7 +25,7 @@
       @debits.map { debit =>
         <div class="tabular-data__entry border-bottom">
           <span class="tabular-data__heading tabular-data__heading--label">
-            <h4 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.dueDate)}</h4>
+            <h4 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.getDueDate)}</h4>
             <p>@charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.dueByYear(1).toString, debit.dueByYear().toString) </p>
           </span>
           <div class="tabular-data__data-1"><span class="normal-text">@partials.currency(debit.amount)</span></div>

--- a/app/views/partials/what_you_owe.scala.html
+++ b/app/views/partials/what_you_owe.scala.html
@@ -31,7 +31,7 @@
         @if(smallFormat && !debits.head.equals(debit)){<br>}
         <div class="@if(smallFormat){grid-layout--no-gutter}else{subsection ssttp-grid-layout-padding-above} grid-layout font-xsmall divider--bottom">
             <div class="grid-layout__column grid-layout__column--3-4">
-                <div><span class="@if(smallFormat){font-xsmall}else{font-small}">@debit.dueDate.format(formatter)</span></div>
+                <div><span class="@if(smallFormat){font-xsmall}else{font-small}">@debit.getDueDate.format(formatter)</span></div>
                 <small>
                     <span class="font-xsmall">@charge_code(debit.originCode, debit.taxYearEnd)</span>
                 </small>

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -29,7 +29,8 @@ private object AppDependencies {
     "com.beachape" %% "enumeratum" % "1.5.15",
     "uk.gov.hmrc" %% "simple-reactivemongo" % "7.22.0-play-26",
 
-    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.27.0]",
+    //"uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.27.0]",
+    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.27.2]",
     "uk.gov.hmrc" %% "time-to-pay-calculator-cor" % "[0.35.0,)",
 
     "uk.gov.hmrc" %% "play-partials" %  "6.9.0-play-26",

--- a/test/eligibility/EligibilityServiceSpec.scala
+++ b/test/eligibility/EligibilityServiceSpec.scala
@@ -175,11 +175,11 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "SA Return not yet submitted by customer" in {
       val debits = List(
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31),
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)),
               interest   = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)),
               interest   = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)),
               interest   = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
@@ -194,9 +194,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "SA Return submitted in future by customer" in {
       val debits = List(
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -210,9 +210,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, total amount > £10k" in {
       val debits = List(
-        Debit(amount     = 5000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 10000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 10000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 5000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 10000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 10000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -226,10 +226,10 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, debt > £32 is older than 29 days" in {
       val debits = List(
-        Debit(amount     = 2000, dueDate = LocalDate.of(2016, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020))
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2016, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020))
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
                            receivedDate = Some(LocalDate.of(2016, 12, 10))) :: Nil
@@ -242,10 +242,10 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, old debt < £32, total amount < £10k" in {
       val debits = List(
-        Debit(amount     = 0, dueDate = LocalDate.of(2016, 6, 10), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 0, dueDate = Some(LocalDate.of(2016, 6, 10)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -259,10 +259,10 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, old returns overdue" in {
       val debits = List(
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = List(
@@ -279,9 +279,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, total amount <£10k" in {
       val debits = List(
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -295,9 +295,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, total amount >£10k with future liability" in {
       val debits = List(
-        Debit(amount     = 3000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 6000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 6000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 3000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 6000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 6000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -311,11 +311,11 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, old debts > £32" in {
       val debits = List(
-        Debit(amount     = 1000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 2000, dueDate = LocalDate.of(2017, 7, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 0, dueDate = LocalDate.of(2016, 1, 31), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
-        Debit(amount     = 0, dueDate = LocalDate.of(2016, 1, 31), interest = Some(Interest(Some(LocalDate.now), 40)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 1000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 2000, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 0, dueDate = Some(LocalDate.of(2016, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 25)), originCode = "IN1", taxYearEnd = taxYearEnd2020),
+        Debit(amount     = 0, dueDate = Some(LocalDate.of(2016, 1, 31)), interest = Some(Interest(Some(LocalDate.now), 40)), originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -329,7 +329,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, total liability > £32" in {
       val debits = List(
-        Debit(amount     = 30, dueDate = LocalDate.of(2017, 7, 31), interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 30, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
@@ -343,7 +343,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
 
     "Return submitted, utr not on ia " in {
       val debits = List(
-        Debit(amount     = 500, dueDate = LocalDate.of(2017, 7, 31), interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020)
+        Debit(amount     = 500, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020)
       )
 
       val returns = Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),

--- a/test/eligibility/EligibilityServiceSpec.scala
+++ b/test/eligibility/EligibilityServiceSpec.scala
@@ -354,6 +354,19 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
                                                                 createTaxpayer(debits, returns)), false) shouldBe Ineligible(List(IsNotOnIa))
     }
+
+    "Fully eligible except no relevantDueDate for a single debit" in {
+      val debits = Seq(
+        Debit(amount     = 500, dueDate = None, interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020), Debit(amount     = 500, dueDate = Some(LocalDate.of(2017, 7, 31)), interest = None, originCode = "IN1", taxYearEnd = taxYearEnd2020)
+      )
+      val returns = Seq(Return(taxYearEnd   = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 4, 5)),
+                               receivedDate = Some(LocalDate.of(2016, 12, 10))))
+
+      val todaysDate = LocalDate.of(2017, 7, 10)
+
+      EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
+                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(DebitHasNoRelevantDueDate))
+    }
   }
 
   val outstandingReturnThisYear = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)))

--- a/test/eligibility/EligibilityServiceSpec.scala
+++ b/test/eligibility/EligibilityServiceSpec.scala
@@ -362,15 +362,15 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
   val lastFourCalendarYears: Seq[Int] = Seq(2012, 2013, 2014, 2015)
 
   def liability(amount: Double, currentDate: LocalDate = beforeTaxYearStart, interest: Option[Interest] = None) =
-    debit(amount, currentDate.plusDays(1), interest = interest)
+    debit(amount, Some(currentDate.plusDays(1)), interest = interest)
 
   def charge(amount: Double, currentDate: LocalDate = beforeTaxYearStart, interest: Option[Interest] = None) =
-    debit(amount, currentDate.minusDays(29), interest = interest)
+    debit(amount, Some(currentDate.minusDays(29)), interest = interest)
 
   def debt(amount: Double, currentDate: LocalDate = beforeTaxYearStart, interest: Option[Interest] = None) =
-    debit(amount, currentDate.minusDays(60), interest = interest)
+    debit(amount, Some(currentDate.minusDays(60)), interest = interest)
 
-  def debit(amount: Double, dueDate: LocalDate, interest: Option[Interest] = None) = {
+  def debit(amount: Double, dueDate: Option[LocalDate], interest: Option[Interest] = None) = {
     Debit(amount     = amount, dueDate = dueDate, interest = interest, originCode = "IN1", taxYearEnd = taxYearEnd2020)
   }
 

--- a/test/pagespecs/AccessibilityStatementPageSpec.scala
+++ b/test/pagespecs/AccessibilityStatementPageSpec.scala
@@ -18,7 +18,6 @@ package pagespecs
 
 import testsupport.ItSpec
 import testsupport.stubs._
-import testsupport.testdata.DirectDebitTd
 
 class AccessibilityStatementPageSpec extends ItSpec {
 
@@ -26,7 +25,7 @@ class AccessibilityStatementPageSpec extends ItSpec {
     {
       AuthStub.authorise()
       TaxpayerStub.getTaxpayer()
-      EligibilityStub.eligible()
+      IaStub.successfulIaCheck
       GgStub.signInPage(port)
       startPage.open()
       startPage.clickOnStartNowButton()

--- a/test/pagespecs/IneligiblePagesSpec.scala
+++ b/test/pagespecs/IneligiblePagesSpec.scala
@@ -21,7 +21,7 @@ import pagespecs.pages.BasePage
 import testsupport.ItSpec
 import testsupport.stubs._
 import uk.gov.hmrc.auth.core.ConfidenceLevel
-import uk.gov.hmrc.selfservicetimetopay.models.{DebtIsInsignificant, IsNotOnIa, NoDebt, OldDebtIsTooHigh, Reason, ReturnNeedsSubmitting, TotalDebtIsTooHigh}
+import uk.gov.hmrc.selfservicetimetopay.models.{DebitHasNoRelevantDueDate, DebtIsInsignificant, IsNotOnIa, NoDebt, OldDebtIsTooHigh, Reason, ReturnNeedsSubmitting, TotalDebtIsTooHigh}
 
 class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
 
@@ -47,7 +47,8 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
     ("current year return not submitted", ReturnNeedsSubmitting, "you need to file", needToFilePage),
     ("debt more than £10k", TotalDebtIsTooHigh, "debt too large", debtTooLargePage),
     ("debt less than £32", DebtIsInsignificant, "debt too small", needToFilePage),
-    ("old debt is more than £32", OldDebtIsTooHigh, "old debt too large", generalCallUsPage)
+    ("old debt is more than £32", OldDebtIsTooHigh, "old debt too large", generalCallUsPage),
+    ("no relevantDueDate present", DebitHasNoRelevantDueDate, "debit has no due date", generalCallUsPage)
   )
 
   def beginJourney(ineligibleReason: Reason): Unit = {

--- a/test/pagespecs/IneligiblePagesSpec.scala
+++ b/test/pagespecs/IneligiblePagesSpec.scala
@@ -43,7 +43,7 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
   val listOfIneligibleReasons: TableFor4[String, Reason, String, BasePage] = Table(
     ("reason", "reasonObject", "pageAsString", "page"),
     ("no debts", NoDebt, "general call us page", generalCallUsPage),
-    ("not on IA", IsNotOnIa, "not on ia page", notOnIaPage),
+    //("not on IA", IsNotOnIa, "not on ia page", notOnIaPage),
     ("current year return not submitted", ReturnNeedsSubmitting, "you need to file", needToFilePage),
     ("debt more than £10k", TotalDebtIsTooHigh, "debt too large", debtTooLargePage),
     ("debt less than £32", DebtIsInsignificant, "debt too small", needToFilePage),

--- a/test/testsupport/stubs/TaxpayerStub.scala
+++ b/test/testsupport/stubs/TaxpayerStub.scala
@@ -22,7 +22,7 @@ import org.scalatest.Matchers
 import play.api.libs.json.Json
 import testsupport.testdata.{EligibilityTaxpayerVariationsTd, TdAll}
 import timetopaytaxpayer.cor.model.Taxpayer
-import uk.gov.hmrc.selfservicetimetopay.models.{DebtIsInsignificant, IsNotOnIa, NoDebt, OldDebtIsTooHigh, Reason, ReturnNeedsSubmitting, TotalDebtIsTooHigh}
+import uk.gov.hmrc.selfservicetimetopay.models.{DebitHasNoRelevantDueDate, DebtIsInsignificant, IsNotOnIa, NoDebt, OldDebtIsTooHigh, Reason, ReturnNeedsSubmitting, TotalDebtIsTooHigh}
 
 object TaxpayerStub extends Matchers {
 
@@ -50,13 +50,14 @@ object TaxpayerStub extends Matchers {
 
   def getIneligibleTaxpayerModel(reason: Reason): Taxpayer = {
     reason match {
-      case NoDebt                => EligibilityTaxpayerVariationsTd.zeroDebtTaxpayer
-      case DebtIsInsignificant   => EligibilityTaxpayerVariationsTd.insignificantDebtTaxpayer
-      case OldDebtIsTooHigh      => EligibilityTaxpayerVariationsTd.oldDebtIsTooHighTaxpayer
-      case TotalDebtIsTooHigh    => EligibilityTaxpayerVariationsTd.totalDebtIsTooHighTaxpayer
-      case ReturnNeedsSubmitting => EligibilityTaxpayerVariationsTd.returnNeedsSubmittingTaxpayer
-      case IsNotOnIa             => EligibilityTaxpayerVariationsTd.notOnIaTaxpayer
-      case _                     => TdAll.taxpayer
+      case NoDebt                    => EligibilityTaxpayerVariationsTd.zeroDebtTaxpayer
+      case DebtIsInsignificant       => EligibilityTaxpayerVariationsTd.insignificantDebtTaxpayer
+      case OldDebtIsTooHigh          => EligibilityTaxpayerVariationsTd.oldDebtIsTooHighTaxpayer
+      case TotalDebtIsTooHigh        => EligibilityTaxpayerVariationsTd.totalDebtIsTooHighTaxpayer
+      case ReturnNeedsSubmitting     => EligibilityTaxpayerVariationsTd.returnNeedsSubmittingTaxpayer
+      case IsNotOnIa                 => EligibilityTaxpayerVariationsTd.notOnIaTaxpayer
+      case DebitHasNoRelevantDueDate => EligibilityTaxpayerVariationsTd.debitHasNoDueDateTaxpayer
+      case _                         => TdAll.taxpayer
     }
   }
 }

--- a/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
+++ b/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
@@ -32,6 +32,9 @@ object EligibilityTaxpayerVariationsTd {
   def initDebit(originCode: String, amount: Double, dueDate: LocalDate): Debit = Debit(originCode, BigDecimal(amount), Some(dueDate),
                                                                                        zeroInterestOption, dummyTaxYearEnd)
 
+  def initNoDueDateDebitButOtherwiseEligibleDebit: Debit = Debit("IN1", BigDecimal(33), None,
+                                                                        zeroInterestOption, dummyTaxYearEnd)
+
   def initEligibleDebit(): Debit = initDebit("IN1", 33, dummyCurrentDate)
 
   def initSelfAssessmentDetails(debits: Seq[Debit], returns: Seq[Return]): SelfAssessmentDetails = SelfAssessmentDetails(TdAll.Sautr, TdAll.communicationPreferences, debits, returns)
@@ -53,4 +56,6 @@ object EligibilityTaxpayerVariationsTd {
   val returnNeedsSubmittingTaxpayer: Taxpayer = initTaxpayer(Seq(initEligibleDebit), Seq(Return(dummyTaxYearEnd, Some(dummy60DaysAgo), Some(dummyCurrentDate), None)))
 
   val notOnIaTaxpayer: Taxpayer = initTaxpayer(Seq(initEligibleDebit), Seq.empty)
+
+  val debitHasNoDueDateTaxpayer: Taxpayer = initTaxpayer(Seq(initNoDueDateDebitButOtherwiseEligibleDebit), Seq.empty)
 }

--- a/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
+++ b/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
@@ -29,7 +29,7 @@ object EligibilityTaxpayerVariationsTd {
   val taxpayerAddress: Address = Address(Some("Golden Throne"), Some("Himalayan Mountains"), Some("Holy Terra"), Some("Segmentum Solar"),
                                          Some("Milky Way Galaxy"), Some("BN11 1XX"))
 
-  def initDebit(originCode: String, amount: Double, dueDate: LocalDate): Debit = Debit(originCode, BigDecimal(amount), dueDate,
+  def initDebit(originCode: String, amount: Double, dueDate: LocalDate): Debit = Debit(originCode, BigDecimal(amount), Some(dueDate),
                                                                                        zeroInterestOption, dummyTaxYearEnd)
 
   def initEligibleDebit(): Debit = initDebit("IN1", 33, dummyCurrentDate)

--- a/test/util/util/CalculatorLogicSpec.scala
+++ b/test/util/util/CalculatorLogicSpec.scala
@@ -35,7 +35,7 @@ class CalculatorLogicSpec extends PlaySpec with TableDrivenPropertyChecks {
     Debit(
       originCode = des,
       amount     = value,
-      dueDate    = LocalDate.parse(dueDate, formatter),
+      dueDate    = Some(LocalDate.parse(dueDate, formatter)),
       interest   = Some(Interest(
         Some(LocalDate.now()),
         interest.getOrElse(BigDecimal(0)))


### PR DESCRIPTION
-updated so that if a user has debits with no relevant due date field then instead of throwing an error it redirects them to the general call us page as this field is apparently not mandatory. 
-added tests
-will need the updated version of SSTTP-taxpayer 2.7 when it is merged
-the corresponding version will also have to be entered into the AppDependencies as is currently using the version of taxpayer I have updated so this will need to be done before final merge/deployment