### PR TITLE
ET-OPS-4163

### DIFF
--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -51,7 +51,7 @@ class AuditService @Inject() (auditConnector: AuditConnector)(implicit ec: Execu
       auditType   = "directDebitSetup",
       tags        = hc.headers.toMap,
       detail      = Json.obj(
-        "utr" -> journey.taxpayer.selfAssessment.utr.value,
+        "utr" -> journey.saUtr,
         "bankDetails" -> Json.obj(
           "name" -> journey.bankDetails.accountName,
           "accountNumber" -> journey.bankDetails.accountNumber,

--- a/app/journey/Journey.scala
+++ b/app/journey/Journey.scala
@@ -23,7 +23,7 @@ import enumformat.EnumFormat
 import journey.Statuses.InProgress
 import play.api.libs.json.{Format, Json, OFormat}
 import timetopaycalculator.cor.model.{CalculatorInput, PaymentSchedule}
-import timetopaytaxpayer.cor.model.Taxpayer
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 import uk.gov.hmrc.selfservicetimetopay.models._
 
 import scala.collection.immutable
@@ -50,16 +50,17 @@ final case class Journey(
     maybeSchedule:          Option[PaymentSchedule]   = None,
     maybeBankDetails:       Option[BankDetails]       = None,
     existingDDBanks:        Option[DirectDebitBank]   = None,
-    maybeTaxpayer:          Option[Taxpayer]          = None,
+    maybeReturnsAndDebits:  Option[ReturnsAndDebits]  = None,
     maybeCalculatorData:    Option[CalculatorInput]   = None,
     durationMonths:         Int                       = 2,
     maybeEligibilityStatus: Option[EligibilityStatus] = None,
     debitDate:              Option[LocalDate]         = None,
-    ddRef:                  Option[String]            = None
+    ddRef:                  Option[String]            = None,
+    maybeSaUtr:             Option[String]            = None
 ) {
 
   def amount: BigDecimal = maybeAmount.getOrElse(throw new RuntimeException(s"Expected 'amount' to be there but was not found. [${_id}] [${this}]"))
-  def taxpayer: Taxpayer = maybeTaxpayer.getOrElse(throw new RuntimeException(s"Expected 'Taxpayer' to be there but was not found. [${_id}] [${this}]"))
+  def returnsAndDebits: ReturnsAndDebits = maybeReturnsAndDebits.getOrElse(throw new RuntimeException(s"Expected 'ReturnsAndDebits' to be there but was not found. [${_id}] [${this}]"))
 
   def calculatorInput: CalculatorInput =
     maybeCalculatorData.getOrElse(throw new RuntimeException(s"Expected 'CalculatorData' to be there but was not found. [${_id}] [${this}]"))
@@ -76,6 +77,8 @@ final case class Journey(
   def schedule: PaymentSchedule =
     maybeSchedule.getOrElse(throw new RuntimeException(s"schedule missing on submission [${_id}]"))
 
+  def saUtr: String = maybeSaUtr.getOrElse(throw new RuntimeException(s"saUtr missing on submission [${_id}]"))
+
   def obfuscate: Journey = Journey(
     _id                    = _id,
     createdOn              = createdOn,
@@ -83,12 +86,13 @@ final case class Journey(
     maybeSchedule          = maybeSchedule,
     maybeBankDetails       = maybeBankDetails.map(_.obfuscate),
     existingDDBanks        = existingDDBanks.map(_.obfuscate),
-    maybeTaxpayer          = maybeTaxpayer.map(_.obfuscate),
+    maybeReturnsAndDebits  = maybeReturnsAndDebits.map(_.obfuscate),
     maybeCalculatorData    = maybeCalculatorData,
     durationMonths         = durationMonths,
     maybeEligibilityStatus = maybeEligibilityStatus,
     debitDate              = debitDate,
-    ddRef                  = ddRef.map(_ => "***")
+    ddRef                  = ddRef.map(_ => "***"),
+    maybeSaUtr             = maybeSaUtr.map(_ => "***")
   )
 }
 

--- a/app/journey/JourneyService.scala
+++ b/app/journey/JourneyService.scala
@@ -59,11 +59,11 @@ class JourneyService @Inject() (
     for {
       journey <- getJourney()
       result <- journey match {
-        case submission @ Journey(_, Statuses.InProgress, _, _, Some(_), _, _, Some(_), _, _, Some(EligibilityStatus(true, _)), _, _) =>
+        case submission @ Journey(_, Statuses.InProgress, _, _, Some(_), _, _, Some(_), _, _, Some(EligibilityStatus(true, _)), _, _, _) =>
           JourneyLogger.info(s"${this.getClass.getSimpleName}.authorizedForSsttp: currentSubmission", submission)
           block(submission)
 
-        case journey @ Journey(_, Statuses.FinishedApplicationSuccessful, _, _, _, _, _, _, _, _, _, _, _) =>
+        case journey @ Journey(_, Statuses.FinishedApplicationSuccessful, _, _, _, _, _, _, _, _, _, _, _, _) =>
           JourneyLogger.info(s"${this.getClass.getSimpleName}.authorizedForSsttp: currentSubmission", journey)
           Future.successful(Results.Redirect(ssttparrangement.routes.ArrangementController.applicationComplete()))
 

--- a/app/ssttparrangement/ArrangementController.scala
+++ b/app/ssttparrangement/ArrangementController.scala
@@ -38,7 +38,7 @@ import ssttpeligibility.EligibilityService.runEligibilityCheck
 import ssttpeligibility.IaService
 import times.ClockProvider
 import timetopaycalculator.cor.model.{CalculatorInput, DebitInput, Instalment, PaymentSchedule}
-import timetopaytaxpayer.cor.model.{SelfAssessmentDetails, Taxpayer}
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 import timetopaytaxpayer.cor.{TaxpayerConnector, model}
 import uk.gov.hmrc.selfservicetimetopay.jlogger.JourneyLogger
 import uk.gov.hmrc.selfservicetimetopay.models._
@@ -77,7 +77,7 @@ class ArrangementController @Inject() (
     JourneyLogger.info(s"ArrangementController.start: $request")
 
     journeyService.getJourney.flatMap {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(_), _, _, _, _, _) => eligibilityCheck(journey)
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(_), _, _, _, _, _, _) => eligibilityCheck(journey)
     }
   }
 
@@ -96,8 +96,8 @@ class ArrangementController @Inject() (
     JourneyLogger.info(s"ArrangementController.determineEligibility: $request")
 
     for {
-      tp: model.Taxpayer <- taxPayerConnector.getTaxPayer(asTaxpayersSaUtr(request.utr))
-      newJourney: Journey = Journey.newJourney.copy(maybeTaxpayer = Some(tp))
+      returnsAndDebits: model.ReturnsAndDebits <- taxPayerConnector.getReturnsAndDebits(asTaxpayersSaUtr(request.utr))
+      newJourney: Journey = Journey.newJourney.copy(maybeReturnsAndDebits = Some(returnsAndDebits), maybeSaUtr = Some(request.utr.value))
       _ <- journeyService.saveJourney(newJourney)
       result: Result <- eligibilityCheck(newJourney)
     } yield result.placeInSession(newJourney._id)
@@ -107,9 +107,9 @@ class ArrangementController @Inject() (
   def getInstalmentSummary: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"ArrangementController.getInstalmentSummary: $request")
     journeyService.authorizedForSsttp {
-      case journey @ Journey(_, InProgress, _, _, Some(schedule), _, _, _, Some(CalculatorInput(_, initialPayment, _, _, _)), _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, Some(schedule), _, _, _, Some(CalculatorInput(_, initialPayment, _, _, _)), _, _, _, _, _) =>
         Future.successful(Ok(views.instalment_plan_summary(
-          journey.taxpayer.selfAssessment.debits,
+          journey.returnsAndDebits.debits,
           initialPayment,
           schedule
         )))
@@ -142,7 +142,7 @@ class ArrangementController @Inject() (
           },
           validFormData => {
             submission match {
-              case _@ Journey(_, InProgress, _, _, Some(schedule), _, _, _, Some(CalculatorInput(debits, _, _, _, _)), _, _, _, _) =>
+              case _@ Journey(_, InProgress, _, _, Some(schedule), _, _, _, Some(CalculatorInput(debits, _, _, _, _)), _, _, _, _, _) =>
                 JourneyLogger.info(s"changing schedule day to [${validFormData.dayOfMonth}]")
                 changeScheduleDay(submission, schedule, debits, validFormData.dayOfMonth).flatMap {
                   ttpSubmission =>
@@ -215,8 +215,8 @@ class ArrangementController @Inject() (
         }
 
     for {
-      onIa <- iaService.checkIaUtr(journey.taxpayer.selfAssessment.utr.value)
-      eligibilityStatus = runEligibilityCheck(EligibilityRequest(LocalDate.now(clockProvider.getClock), journey.taxpayer), onIa)
+      onIa <- iaService.checkIaUtr(journey.saUtr)
+      eligibilityStatus = runEligibilityCheck(EligibilityRequest(LocalDate.now(clockProvider.getClock), journey.returnsAndDebits), onIa)
       newJourney: Journey = journey.copy(maybeEligibilityStatus = Option(eligibilityStatus))
       _ <- journeyService.saveJourney(newJourney)
       _ = JourneyLogger.info(s"ArrangementController.eligibilityCheck [eligible=${eligibilityStatus.eligible}]", newJourney)
@@ -244,8 +244,8 @@ class ArrangementController @Inject() (
             throw new RuntimeException(s"arrangementDirectDebit not found for journey [$journey]"))
 
         Ok(views.application_complete(
-          debits        = journey.taxpayer.selfAssessment.debits.sortBy(_.dueDate.toEpochDay()),
-          transactionId = journey.taxpayer.selfAssessment.utr + LocalDateTime.now(clockProvider.getClock).toString,
+          debits        = journey.returnsAndDebits.debits.sortBy(_.dueDate.toEpochDay()),
+          transactionId = journey.saUtr + LocalDateTime.now(clockProvider.getClock).toString,
           directDebit,
           journey.schedule,
           journey.ddRef
@@ -263,9 +263,9 @@ class ArrangementController @Inject() (
    */
   private def arrangementSetUp(journey: Journey)(implicit request: Request[_]): Future[Result] = {
     JourneyLogger.info("ArrangementController.arrangementSetUp: (create a DD and make an Arrangement)")
-    journey.maybeTaxpayer match {
-      case Some(Taxpayer(_, _, SelfAssessmentDetails(utr, _, _, _))) =>
-        ddConnector.createPaymentPlan(checkExistingBankDetails(journey), utr).flatMap[Result] {
+    journey.maybeReturnsAndDebits match {
+      case Some(ReturnsAndDebits(_, _)) =>
+        ddConnector.createPaymentPlan(checkExistingBankDetails(journey), journey.saUtr).flatMap[Result] {
           _.fold(_ => {
             JourneyLogger.info("ArrangementController.arrangementSetUp: dd setup failed, redirecting to error page")
             Redirect(ssttpdirectdebit.routes.DirectDebitController.getDirectDebitError())
@@ -325,7 +325,7 @@ class ArrangementController @Inject() (
    * Builds and returns a payment plan
    */
   private def paymentPlan(journey: Journey, ddInstruction: DirectDebitInstruction): PaymentPlanRequest = {
-    val knownFact = List(KnownFact(cesa, journey.taxpayer.selfAssessment.utr.value))
+    val knownFact = List(KnownFact(cesa, journey.saUtr))
 
     val initialPayment = if (journey.schedule.initialPayment > exact(0)) Some(journey.schedule.initialPayment.toString()) else None
     val initialStartDate = initialPayment.fold[Option[LocalDate]](None)(_ => Some(journey.schedule.startDate.plusWeeks(1)))
@@ -336,7 +336,7 @@ class ArrangementController @Inject() (
     val totalLiability = journey.schedule.instalments.map(_.amount).sum + journey.schedule.initialPayment
 
     val pp = PaymentPlan(ppType                    = "Time to Pay",
-                         paymentReference          = s"${journey.taxpayer.selfAssessment.utr.value}K",
+                         paymentReference          = s"${journey.saUtr}K",
                          hodService                = cesa,
                          paymentCurrency           = paymentCurrency,
                          initialPaymentAmount      = initialPayment,
@@ -365,10 +365,10 @@ class ArrangementController @Inject() (
         .headOption.getOrElse(throw new RuntimeException(s"No direct debit instructions for [$ddInstruction]"))
         .ddiReferenceNo.getOrElse(throw new RuntimeException("ddReference not available"))
 
-    val taxpayer = journey.taxpayer
+    val returnsAndDebits = journey.returnsAndDebits
     val schedule = journey.schedule
 
-    TTPArrangement(ppReference, ddReference, taxpayer, schedule)
+    TTPArrangement(ppReference, ddReference, returnsAndDebits, schedule)
   }
 
   private def createDayOfForm(journey: Journey) =

--- a/app/ssttpcalculator/CalculatorController.scala
+++ b/app/ssttpcalculator/CalculatorController.scala
@@ -55,7 +55,7 @@ class CalculatorController @Inject() (
   def getTaxLiabilities: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.getTaxLiabilities: $request")
     journeyService.getJourney.map {
-      case _@ Journey(_, InProgress, _, _, _, _, _, Some(ReturnsAndDebits(debits, returns)), _, _, _, _, _, _) =>
+      case _@ Journey(_, InProgress, _, _, _, _, _, Some(ReturnsAndDebits(debits, _)), _, _, _, _, _, _) =>
         Ok(views.tax_liabilities(debits, isSignedIn))
       case journey =>
         JourneyLogger.info(s"CalculatorController.getTaxLiabilities: pattern match redirect on error", journey)

--- a/app/ssttpcalculator/CalculatorController.scala
+++ b/app/ssttpcalculator/CalculatorController.scala
@@ -31,7 +31,7 @@ import ssttpcalculator.CalculatorForm.{createInstalmentForm, createMonthlyAmount
 import ssttpcalculator.CalculatorService.{createCalculatorInput, maximumDurationInMonths, minimumMonthsAllowedTTP}
 import times.ClockProvider
 import timetopaycalculator.cor.model.{CalculatorInput, PaymentSchedule}
-import timetopaytaxpayer.cor.model.{SelfAssessmentDetails, Taxpayer}
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.selfservicetimetopay.jlogger.JourneyLogger
 import uk.gov.hmrc.selfservicetimetopay.models._
@@ -55,8 +55,8 @@ class CalculatorController @Inject() (
   def getTaxLiabilities: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.getTaxLiabilities: $request")
     journeyService.getJourney.map {
-      case _@ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
-        Ok(views.tax_liabilities(sa.debits, isSignedIn))
+      case _@ Journey(_, InProgress, _, _, _, _, _, Some(ReturnsAndDebits(debits, returns)), _, _, _, _, _, _) =>
+        Ok(views.tax_liabilities(debits, isSignedIn))
       case journey =>
         JourneyLogger.info(s"CalculatorController.getTaxLiabilities: pattern match redirect on error", journey)
         technicalDifficulties(journey)
@@ -76,7 +76,7 @@ class CalculatorController @Inject() (
     JourneyLogger.info(s"CalculatorController.submitPayTodayQuestion: $request")
 
     journeyService.getJourney.flatMap[Result] {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, _, _, _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, _, _, _, _, _, _, _) =>
         payTodayForm.bindFromRequest().fold(
           formWithErrors => Future.successful(BadRequest(views.payment_today_question(formWithErrors, isSignedIn))), {
             case PayTodayQuestion(Some(true)) =>
@@ -88,7 +88,7 @@ class CalculatorController @Inject() (
                     0,
                     LocalDate.now(clockProvider.getClock).getDayOfMonth,
                     0,
-                    journey.taxpayer.selfAssessment.debits.map(model.asDebitInput))))
+                    journey.returnsAndDebits.debits.map(model.asDebitInput))))
               journeyService.saveJourney(newJourney).map[Result] {
                 _ => Redirect(ssttpcalculator.routes.CalculatorController.getMonthlyPayment())
               }
@@ -103,7 +103,7 @@ class CalculatorController @Inject() (
   def getPaymentToday: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.getPaymentToday: $request")
     journeyService.getJourney.map {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, SelfAssessmentDetails(_, _, debits, _))), _, _, _, _, _) if debits.nonEmpty =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(ReturnsAndDebits(debits, _)), _, _, _, _, _, _) if debits.nonEmpty =>
         val newJourney =
           journey.copy(maybeCalculatorData =
             Some(createCalculatorInput(
@@ -123,7 +123,7 @@ class CalculatorController @Inject() (
   def submitPaymentToday: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.submitPaymentToday: $request")
     journeyService.getJourney.flatMap[Result] {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, _, Some(_), _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, _, Some(_), _, _, _, _, _) =>
         createPaymentTodayForm(journey.calculatorInput.debits.map(_.amount).sum).bindFromRequest().fold(
           formWithErrors => Future.successful(BadRequest(views.payment_today_form(formWithErrors, isSignedIn))),
           validFormData => {
@@ -142,19 +142,19 @@ class CalculatorController @Inject() (
   def getMonthlyPayment: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.getMonthlyPayment: $request")
     journeyService.getJourney.flatMap[Result] {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(returnsAndDebits), _, _, _, _, _, _) =>
         val form = createMonthlyAmountForm(
-          lowerMonthlyPaymentBound(sa, journey.calculatorInput).toInt, upperMonthlyPaymentBound(sa, journey.calculatorInput).toInt)
+          lowerMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput).toInt, upperMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput).toInt)
         Future.successful(Ok(views.monthly_amount(
-          form, upperMonthlyPaymentBound(sa, journey.calculatorInput), lowerMonthlyPaymentBound(sa, journey.calculatorInput))))
+          form, upperMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput), lowerMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput))))
       case journey =>
         JourneyLogger.info(s"CalculatorController.getMonthlyPayment: pattern match redirect on error", journey)
         Future.successful(technicalDifficulties(journey))
     }
   }
 
-  private def upperMonthlyPaymentBound(sa: SelfAssessmentDetails, calculatorData: CalculatorInput)(implicit hc: HeaderCarrier): String =
-    Try(roundUpToNearestHundred((sa.debits.map(_.amount).sum - calculatorData.initialPayment) / minimumMonthsAllowedTTP).toString) match {
+  private def upperMonthlyPaymentBound(returnsAndDebits: ReturnsAndDebits, calculatorData: CalculatorInput)(implicit hc: HeaderCarrier): String =
+    Try(roundUpToNearestHundred((returnsAndDebits.debits.map(_.amount).sum - calculatorData.initialPayment) / minimumMonthsAllowedTTP).toString) match {
       case Success(s) =>
         JourneyLogger.info(s"CalculatorController.upperMonthlyPaymentBound: [$s]")
         s
@@ -163,11 +163,11 @@ class CalculatorController @Inject() (
         throw e
     }
 
-  private def lowerMonthlyPaymentBound(sa: SelfAssessmentDetails, calculatorData: CalculatorInput)(implicit request: Request[_]): String =
+  private def lowerMonthlyPaymentBound(returnsAndDebits: ReturnsAndDebits, calculatorData: CalculatorInput)(implicit request: Request[_]): String =
     Try(
       roundDownToNearestHundred(
-        (sa.debits.map(_.amount).sum - calculatorData.initialPayment) /
-          maximumDurationInMonths(sa, LocalDate.now(clockProvider.getClock))).toString) match {
+        (returnsAndDebits.debits.map(_.amount).sum - calculatorData.initialPayment) /
+          maximumDurationInMonths(returnsAndDebits, LocalDate.now(clockProvider.getClock))).toString) match {
         case Success(s) =>
           JourneyLogger.info(s"CalculatorController.lowerMonthlyPaymentBound: [$s]")
           s
@@ -183,14 +183,14 @@ class CalculatorController @Inject() (
   def submitMonthlyPayment: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.submitMonthlyPayment: $request")
     journeyService.getJourney.flatMap {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(returnsAndDebits), _, _, _, _, _, _) =>
 
-        calculatorService.getInstalmentsSchedule(sa, journey.calculatorInput.initialPayment).flatMap { _ =>
+        calculatorService.getInstalmentsSchedule(returnsAndDebits, journey.calculatorInput.initialPayment).flatMap { _ =>
           createMonthlyAmountForm(
-            lowerMonthlyPaymentBound(sa, journey.calculatorInput).toInt, upperMonthlyPaymentBound(sa, journey.calculatorInput).toInt).bindFromRequest().fold(
+            lowerMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput).toInt, upperMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput).toInt).bindFromRequest().fold(
               formWithErrors => {
                 Future.successful(BadRequest(views.monthly_amount(
-                  formWithErrors, upperMonthlyPaymentBound(sa, journey.calculatorInput), lowerMonthlyPaymentBound(sa, journey.calculatorInput)
+                  formWithErrors, upperMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput), lowerMonthlyPaymentBound(returnsAndDebits, journey.calculatorInput)
                 )))
               },
               validFormData => {
@@ -219,27 +219,27 @@ class CalculatorController @Inject() (
     }
   }
 
-  def closestSchedules(closestSchedule: PaymentSchedule, schedules: List[PaymentSchedule], sa: SelfAssessmentDetails)
+  def closestSchedules(closestSchedule: PaymentSchedule, schedules: List[PaymentSchedule], returnsAndDebits: ReturnsAndDebits)
     (implicit request: Request[_]): List[PaymentSchedule] = {
     val closestScheduleIndex = schedules.indexOf(closestSchedule)
 
-    def scheduleMonthsLater(n: Int): Option[PaymentSchedule] = closestScheduleIndex match {
-      case -1 => None
-      case i if i + n >= schedules.size => None
-      case m => Some(schedules(m + n))
-    }
+      def scheduleMonthsLater(n: Int): Option[PaymentSchedule] = closestScheduleIndex match {
+        case -1                           => None
+        case i if i + n >= schedules.size => None
+        case m                            => Some(schedules(m + n))
+      }
 
-    def scheduleMonthsBefore(n: Int): Option[PaymentSchedule] = closestScheduleIndex match {
-      case -1 => None
-      case i if i - n < 0 => None
-      case m => Some(schedules(m - n))
-    }
+      def scheduleMonthsBefore(n: Int): Option[PaymentSchedule] = closestScheduleIndex match {
+        case -1             => None
+        case i if i - n < 0 => None
+        case m              => Some(schedules(m - n))
+      }
 
     if (closestScheduleIndex == 0)
       List(Some(closestSchedule), scheduleMonthsLater(1), scheduleMonthsLater(2))
     else if (closestScheduleIndex == schedules.size - 1)
       List(scheduleMonthsBefore(2), scheduleMonthsBefore(1), Some(closestSchedule))
-    else if (closestScheduleIndex == maximumDurationInMonths(sa, LocalDate.now(clockProvider.getClock)) - 2)
+    else if (closestScheduleIndex == maximumDurationInMonths(returnsAndDebits, LocalDate.now(clockProvider.getClock)) - 2)
       List(scheduleMonthsBefore(2), scheduleMonthsBefore(1), Some(closestSchedule))
     else
       List(scheduleMonthsBefore(1), Some(closestSchedule), scheduleMonthsLater(1))
@@ -248,8 +248,8 @@ class CalculatorController @Inject() (
   def getPaymentSummary: Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.getPaymentSummary: $request")
     journeyService.getJourney.map {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, _, Some(CalculatorInput(debits, initialPayment, _, _, _)), _, _, _, _) if debits.nonEmpty =>
-        Ok(views.payment_summary(journey.taxpayer.selfAssessment.debits, initialPayment))
+      case journey @ Journey(_, InProgress, _, _, _, _, _, _, Some(CalculatorInput(debits, initialPayment, _, _, _)), _, _, _, _, _) if debits.nonEmpty =>
+        Ok(views.payment_summary(journey.returnsAndDebits.debits, initialPayment))
       case journey =>
         JourneyLogger.info(s"CalculatorController.getPaymentSummary: pattern match redirect on error", journey)
         technicalDifficulties(journey)
@@ -260,14 +260,14 @@ class CalculatorController @Inject() (
     JourneyLogger.info(s"CalculatorController.getCalculateInstalments: $request")
 
     journeyService.getJourney.flatMap {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(returnsAndDebits), _, _, _, _, _, _) =>
         JourneyLogger.info("CalculatorController.getCalculateInstalments", journey)
 
-        calculatorService.getInstalmentsSchedule(sa, journey.calculatorInput.initialPayment).map { schedule =>
+        calculatorService.getInstalmentsSchedule(returnsAndDebits, journey.calculatorInput.initialPayment).map { schedule =>
           Ok(views.calculate_instalments_form(
             routes.CalculatorController.submitCalculateInstalments(),
             createInstalmentForm(),
-            closestSchedules(closestSchedule(journey.amount, schedule), schedule, sa)))
+            closestSchedules(closestSchedule(journey.amount, schedule), schedule, returnsAndDebits)))
         }
 
       case journey =>
@@ -279,10 +279,10 @@ class CalculatorController @Inject() (
   def submitCalculateInstalments(): Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     JourneyLogger.info(s"CalculatorController.submitCalculateInstalments: $request")
     journeyService.getJourney.flatMap {
-      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(Taxpayer(_, _, sa)), _, _, _, _, _) =>
+      case journey @ Journey(_, InProgress, _, _, _, _, _, Some(returnsAndDebits), _, _, _, _, _, _) =>
         JourneyLogger.info("CalculatorController.submitCalculateInstalments", journey)
 
-        calculatorService.getInstalmentsSchedule(sa, journey.calculatorInput.initialPayment).flatMap { schedules: List[PaymentSchedule] =>
+        calculatorService.getInstalmentsSchedule(returnsAndDebits, journey.calculatorInput.initialPayment).flatMap { schedules: List[PaymentSchedule] =>
           createInstalmentForm().bindFromRequest().fold(
             formWithErrors =>
               Future.successful(
@@ -290,7 +290,7 @@ class CalculatorController @Inject() (
                   views.calculate_instalments_form(
                     ssttpcalculator.routes.CalculatorController.submitCalculateInstalments(),
                     formWithErrors,
-                    closestSchedules(closestSchedule(journey.amount, schedules), schedules, sa)))),
+                    closestSchedules(closestSchedule(journey.amount, schedules), schedules, returnsAndDebits)))),
             validFormData =>
               journeyService.saveJourney(journey.copy(maybeSchedule = schedules.find(_.durationInMonths == validFormData.chosenMonths))).map { _ =>
                 Redirect(ssttparrangement.routes.ArrangementController.getChangeSchedulePaymentDay())

--- a/app/ssttpdirectdebit/DirectDebitConnector.scala
+++ b/app/ssttpdirectdebit/DirectDebitConnector.scala
@@ -42,10 +42,10 @@ class DirectDebitConnector @Inject() (
 
   val baseUrl: String = servicesConfig.baseUrl("direct-debit")
 
-  def createPaymentPlan(paymentPlan: PaymentPlanRequest, saUtr: SaUtr)(implicit request: Request[_]): Future[DDSubmissionResult] = {
+  def createPaymentPlan(paymentPlan: PaymentPlanRequest, saUtr: String)(implicit request: Request[_]): Future[DDSubmissionResult] = {
     JourneyLogger.info(s"DirectDebitConnector.createPaymentPlan")
 
-    httpClient.POST[PaymentPlanRequest, DirectDebitInstructionPaymentPlan](s"$baseUrl/direct-debit/${saUtr.value}/instructions/payment-plan", paymentPlan).map {
+    httpClient.POST[PaymentPlanRequest, DirectDebitInstructionPaymentPlan](s"$baseUrl/direct-debit/${saUtr}/instructions/payment-plan", paymentPlan).map {
       Result => Right(Result)
     }.recover {
       case e: Throwable =>

--- a/app/ssttpeligibility/EligibilityService.scala
+++ b/app/ssttpeligibility/EligibilityService.scala
@@ -18,7 +18,7 @@ package ssttpeligibility
 
 import java.time.{LocalDate, MonthDay}
 
-import timetopaytaxpayer.cor.model.{Debit, Return, SelfAssessmentDetails}
+import timetopaytaxpayer.cor.model.{Debit, Return, ReturnsAndDebits}
 import uk.gov.hmrc.selfservicetimetopay.models._
 /**
  * Determines if a tax payer is eligible for self service.
@@ -38,11 +38,11 @@ object EligibilityService {
   val taxYearEndDay: MonthDay = MonthDay.of(4, 5)
 
   def runEligibilityCheck(eligibilityRequest: EligibilityRequest, onIa: Boolean): EligibilityStatus = {
-    val selfAssessmentDetails: SelfAssessmentDetails = eligibilityRequest.taxpayer.selfAssessment
+    val returnsAndDebits: ReturnsAndDebits = eligibilityRequest.returnsAndDebits
     val isOnIa: List[Reason] = if (onIa) Nil else List(IsNotOnIa)
 
-    val reasons = (checkReturnsUpToDate(selfAssessmentDetails.returns, eligibilityRequest.dateOfEligibilityCheck)
-      ++ checkDebits(selfAssessmentDetails.debits, eligibilityRequest.dateOfEligibilityCheck) ++ isOnIa)
+    val reasons = (checkReturnsUpToDate(returnsAndDebits.returns, eligibilityRequest.dateOfEligibilityCheck)
+      ++ checkDebits(returnsAndDebits.debits, eligibilityRequest.dateOfEligibilityCheck) ++ isOnIa)
     reasons match {
       case Nil => EligibilityStatus(true, Seq.empty)
       case _   => EligibilityStatus(false, reasons.map(r => r))

--- a/app/testonly/InspectorController.scala
+++ b/app/testonly/InspectorController.scala
@@ -56,7 +56,7 @@ class InspectorController @Inject() (
       request.session.data,
       List(
         "debitDate" -> maybeJourney.flatMap(_.debitDate).json,
-        "taxpayer" -> maybeJourney.flatMap(_.maybeTaxpayer).json,
+        "taxpayer" -> maybeJourney.flatMap(_.maybeReturnsAndDebits).json,
         "schedule" -> maybeJourney.flatMap(_.maybeSchedule).json,
         "bankDetails" -> maybeJourney.flatMap(_.maybeBankDetails).json,
         "existingDDBanks" -> maybeJourney.flatMap(_.existingDDBanks).json,

--- a/app/testonly/TestOnlyController.scala
+++ b/app/testonly/TestOnlyController.scala
@@ -43,14 +43,14 @@ class TestOnlyController @Inject() (
     Results.Ok(result)
   }
 
-  def getTaxpayer(): Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
+  def getReturnsAndDebits(): Action[AnyContent] = as.authorisedSaUser.async { implicit request =>
     val utr: SaUtr = model.asTaxpayersSaUtr(request.utr)
-    val getTaxpayerF = taxpayerConnector.getTaxPayer(utr).map(Json.toJson(_)).recover{
+    val getReturnsAndDebitsF = taxpayerConnector.getReturnsAndDebits(utr).map(Json.toJson(_)).recover{
       case e => Json.obj("exception" -> e.getMessage)
     }
 
     for {
-      taxpayer <- getTaxpayerF
+      taxpayer <- getReturnsAndDebitsF
     } yield Ok(taxpayer)
   }
 

--- a/app/uk/gov/hmrc/selfservicetimetopay/jlogger/JourneyLogger.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/jlogger/JourneyLogger.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.selfservicetimetopay.jlogger
 import journey.Journey
 import play.api.Logger
 import play.api.libs.json.{JsValue, Json}
-import timetopaytaxpayer.cor.model.SelfAssessmentDetails
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.logging.SessionId
 import uk.gov.hmrc.selfservicetimetopay.models.TTPArrangement
@@ -30,7 +30,7 @@ object JourneyLogger {
   def info(sessionId: SessionId, message: => String, data: JsValue): Unit = logger.info(s"$message [sessionId=${sessionId.value}]\n${Json.prettyPrint(data)}")
   def info(message: => String, data: JsValue)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(hc.sessionId.getOrElse(SessionId("NoSessionId")), message, data)
   def info(message: => String, journey: Journey)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(message, Json.toJson(journey.obfuscate))
-  def info(message: => String, selfAssessment: SelfAssessmentDetails)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(message, Json.toJson(selfAssessment.obfuscate))
+  def info(message: => String, returnsAndDebits: ReturnsAndDebits)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(message, Json.toJson(returnsAndDebits.obfuscate))
   def info(message: => String, journey: Option[Journey] = None)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(message, Json.toJson(journey.map(_.obfuscate)))
   def info(message: => String, arrangement: TTPArrangement)(implicit hc: HeaderCarrier): Unit = JourneyLogger.info(message, Json.toJson(arrangement.obfuscate))
 }

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/EligibilityRequest.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/EligibilityRequest.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.selfservicetimetopay.models
 import java.time.LocalDate
 
 import play.api.libs.json.{Format, Json}
-import timetopaytaxpayer.cor.model.Taxpayer
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 
 final case class EligibilityRequest(
     dateOfEligibilityCheck: LocalDate,
-    taxpayer:               Taxpayer
+    returnsAndDebits:       ReturnsAndDebits
 )
 
 object EligibilityRequest {

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/TTPArrangement.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/TTPArrangement.scala
@@ -18,17 +18,17 @@ package uk.gov.hmrc.selfservicetimetopay.models
 
 import play.api.libs.json.{Json, OFormat}
 import timetopaycalculator.cor.model.PaymentSchedule
-import timetopaytaxpayer.cor.model.Taxpayer
+import timetopaytaxpayer.cor.model.ReturnsAndDebits
 
 final case class TTPArrangement(paymentPlanReference: String,
                                 directDebitReference: String,
-                                taxpayer:             Taxpayer,
+                                returnsAndDebits:     ReturnsAndDebits,
                                 schedule:             PaymentSchedule) {
 
   def obfuscate = TTPArrangement(
     paymentPlanReference = paymentPlanReference,
     directDebitReference = directDebitReference,
-    taxpayer             = taxpayer.obfuscate,
+    returnsAndDebits     = returnsAndDebits.obfuscate,
     schedule             = schedule
   )
 }

--- a/app/views/accessibility/accessibility_statement.scala.html
+++ b/app/views/accessibility/accessibility_statement.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import helpers.{highlight, message_list}
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import partials.tax_liabilities_summary
 @import helpers.forms.submit
 

--- a/app/views/arrangement/direct_debit_assistance.scala.html
+++ b/app/views/arrangement/direct_debit_assistance.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import helpers.highlight
 @import partials.{what_you_owe, currency}
 @import timetopaytaxpayer.cor.model.Debit

--- a/app/views/arrangement/terms_and_conditions.scala.html
+++ b/app/views/arrangement/terms_and_conditions.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import helpers.{highlight, message_list}
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import partials.tax_liabilities_summary
 @import helpers.forms.submit
 

--- a/app/views/calculator/payment_summary.scala.html
+++ b/app/views/calculator/payment_summary.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import helpers.forms.submit
 @import timetopaytaxpayer.cor.model.Debit
 @import partials.currency

--- a/app/views/calculator/tax_liabilities.scala.html
+++ b/app/views/calculator/tax_liabilities.scala.html
@@ -20,8 +20,6 @@
 @import java.time.format.DateTimeFormatter
 @import java.util.Locale
 
-@import timetopaytaxpayer.cor.model.Taxpayer
-
 @this(
   main: views.html.main,
   viewsHelpers: views.ViewsHelpers

--- a/app/views/partials/gaDoCheckout.scala.html
+++ b/app/views/partials/gaDoCheckout.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import timetopaytaxpayer.cor.model.Debit
 @import config.AppConfig
 

--- a/app/views/partials/gaDoTransaction.scala.html
+++ b/app/views/partials/gaDoTransaction.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import timetopaytaxpayer.cor.model.Taxpayer
 @import java.time.LocalDate
 @import timetopaytaxpayer.cor.model.Debit
 

--- a/app/views/testonly/inspector.scala.html
+++ b/app/views/testonly/inspector.scala.html
@@ -46,7 +46,7 @@
             <li><a class="link" href="@_root_.testonly.routes.InspectorController.clearPlaySession()">clear play session</a></li>
             <li><a class="link" href="@_root_.testonly.routes.TestUsersController.testUsers()">create user and log in</a></li>
             <li><a class="link" href="@_root_.testonly.routes.TestOnlyController.config()">show config of 'frontend' microservice</a></li>
-            <li><a class="link" href="@_root_.testonly.routes.TestOnlyController.getTaxpayer()">show taxpayer</a></li>
+            <li><a class="link" href="@_root_.testonly.routes.TestOnlyController.getReturnsAndDebits()">show returns and debits</a></li>
         </ul>
     </p>
 

--- a/conf/testOnlyDoNotUseInProd.routes
+++ b/conf/testOnlyDoNotUseInProd.routes
@@ -7,4 +7,4 @@ GET         /pay-what-you-owe-in-instalments/test-only/create-user-and-log-in   
 POST        /pay-what-you-owe-in-instalments/test-only/create-user-and-log-in            testonly.TestUsersController.logIn()
 
 GET         /pay-what-you-owe-in-instalments/test-only/config                            testonly.TestOnlyController.config()
-GET         /pay-what-you-owe-in-instalments/test-only/taxpayer-get                      testonly.TestOnlyController.getTaxpayer()
+GET         /pay-what-you-owe-in-instalments/test-only/taxpayer-get                      testonly.TestOnlyController.getReturnsAndDebits()

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     "com.beachape" %% "enumeratum" % "1.5.15",
     "uk.gov.hmrc" %% "simple-reactivemongo" % "7.22.0-play-26",
 
-    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.30.1]",
+    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.30.0,)",
     "uk.gov.hmrc" %% "time-to-pay-calculator-cor" % "[0.35.0,)",
 
     "uk.gov.hmrc" %% "domain" %  "5.3.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     "com.beachape" %% "enumeratum" % "1.5.15",
     "uk.gov.hmrc" %% "simple-reactivemongo" % "7.22.0-play-26",
 
-    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.27.0]",
+    "uk.gov.hmrc" %% "time-to-pay-taxpayer-cor" % "[0.30.1]",
     "uk.gov.hmrc" %% "time-to-pay-calculator-cor" % "[0.35.0,)",
 
     "uk.gov.hmrc" %% "domain" %  "5.3.0",

--- a/test/eligibility/EligibilityServiceSpec.scala
+++ b/test/eligibility/EligibilityServiceSpec.scala
@@ -21,7 +21,7 @@ import java.time.LocalDate
 import org.scalatest.{Matchers, WordSpecLike}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import ssttpeligibility.EligibilityService
-import timetopaytaxpayer.cor.model.{Address, CommunicationPreferences, Debit, Interest, Return, SaUtr, SelfAssessmentDetails, Taxpayer}
+import timetopaytaxpayer.cor.model.{Address, CommunicationPreferences, Debit, Interest, Return, SaUtr, SelfAssessmentDetails, ReturnsAndDebits}
 import uk.gov.hmrc.selfservicetimetopay.models._
 
 class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with Matchers {
@@ -41,7 +41,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val returns = lastFourCalendarYears.map(filedReturn)
       val debts = Seq(charge(200))
 
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns)), true) shouldBe Eligible
     }
 
     """grant eligibility if all returns for last four years are filed but five years ago a return remains unfiled
@@ -49,7 +49,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val returns = lastFourCalendarYears.map(filedReturn) :+ unFiledReturn(2011)
       val debts = Seq(charge(200))
 
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns)), true) shouldBe Eligible
     }
 
     """not grant eligibility if all returns are filed except the most recent which is still outstanding but not overdue
@@ -58,7 +58,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debts = Seq(charge(200, afterTaxYearStart))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(afterTaxYearStart,
-                                                                createTaxpayer(debts, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
+                                                                createReturnsAndDebits(debts, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     """not grant eligibility if a return in the last four years has been issued and is overdue
@@ -66,24 +66,24 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debts = Seq(charge(200))
 
       val returns = replaceYearWith(lastFourCalendarYears.map(filedReturn), 2013, unFiledReturn(2013))
-      val result = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns)), true)
+      val result = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns)), true)
       result shouldBe Ineligible(List(ReturnNeedsSubmitting))
 
       val returns2 = replaceYearWith(lastFourCalendarYears.map(filedReturn), 2015, unFiledReturn(2015))
-      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns2)), true)
+      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns2)), true)
       result2 shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     """grant eligibility if all returns issued have been filed in last four years
       |and all amounts owed are liabilities""".stripMargin in {
       val debts = Seq(charge(200))
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, Nil)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, Nil)), true) shouldBe Eligible
 
       val returns2 = lastFourCalendarYears.map(unissuedReturn)
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns2)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns2)), true) shouldBe Eligible
 
       val returns3 = replaceYearWith(lastFourCalendarYears.map(filedReturn), 2012, unissuedReturn(2012))
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debts, returns3)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debts, returns3)), true) shouldBe Eligible
     }
 
     "not grant eligibility if this years return is overdue and all amounts owed are liabilities" in {
@@ -91,7 +91,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debts = Seq(charge(200, afterTaxYearStart))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(afterTaxYearStart,
-                                                                createTaxpayer(debts, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
+                                                                createReturnsAndDebits(debts, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     "not grant eligibility if all returns are filed and charges total less than £32" in {
@@ -99,9 +99,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val singleDebtLessThan32Pounds = Seq(charge(11))
       val combinedDebtsLessThan32Pounds = Seq(charge(10), charge(21))
 
-      val result1 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(singleDebtLessThan32Pounds, returns)), true)
+      val result1 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(singleDebtLessThan32Pounds, returns)), true)
       result1 shouldBe Ineligible(List(DebtIsInsignificant))
-      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(combinedDebtsLessThan32Pounds, returns)), true)
+      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(combinedDebtsLessThan32Pounds, returns)), true)
       result2 shouldBe Ineligible(List(DebtIsInsignificant))
     }
 
@@ -110,17 +110,17 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val singleDebtOver1000Pounds = Seq(charge(10000.01))
       val combinedDebtOver1000Pounds = Seq(charge(2000), charge(9000))
 
-      val result = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(singleDebtOver1000Pounds, returns)), true)
+      val result = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(singleDebtOver1000Pounds, returns)), true)
       result shouldBe Ineligible(List(TotalDebtIsTooHigh))
 
-      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(combinedDebtOver1000Pounds, returns)), true)
+      val result2 = EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(combinedDebtOver1000Pounds, returns)), true)
       result2 shouldBe Ineligible(List(TotalDebtIsTooHigh))
     }
 
     "not grant eligibility if all returns are filed and no debts are owed" in {
       val returns = lastFourCalendarYears.map(filedReturn)
 
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(Nil, returns)), true) shouldBe Ineligible(List(NoDebt))
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(Nil, returns)), true) shouldBe Ineligible(List(NoDebt))
     }
 
     "not grant eligibility if all returns are filed and debt over 59 days is over £32" in {
@@ -128,7 +128,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debts = Seq(debt(32.01))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debts, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
+                                                                createReturnsAndDebits(debts, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
     }
 
     "grant eligibility if all returns are filed and debt over 29 days is £32 and charges or liabilities are £9967.99" in {
@@ -136,8 +136,8 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debitsWithCharge = Seq(debt(32.00), charge(9967.99))
       val debitsWithLiabilities = Seq(debt(32.00), liability(9967.99))
 
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debitsWithCharge, returns)), true) shouldBe Eligible
-      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createTaxpayer(debitsWithLiabilities, returns)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debitsWithCharge, returns)), true) shouldBe Eligible
+      EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart, createReturnsAndDebits(debitsWithLiabilities, returns)), true) shouldBe Eligible
     }
 
     "not grant eligibility if all returns are filed and debt over 59 days is £32.01 and charges or liabilities are £9967.99" in {
@@ -146,9 +146,9 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debitsWithLiabilities = Seq(debt(32.01), liability(9967.99))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debitsWithCharge, returns)), onIa = true) shouldBe Ineligible(List(OldDebtIsTooHigh, TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debitsWithCharge, returns)), onIa = true) shouldBe Ineligible(List(OldDebtIsTooHigh, TotalDebtIsTooHigh))
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debitsWithLiabilities, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh, TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debitsWithLiabilities, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh, TotalDebtIsTooHigh))
     }
 
     "not grant eligibility if all returns are filed and liabilities total over £10k" in {
@@ -156,7 +156,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debits = Seq(liability(10000.01))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
     }
 
     "consider interest as debt for its rules" in {
@@ -166,11 +166,11 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debits10k = Seq(charge(9000, interest = Some(Interest(optionalNow, 1000))))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debitsOver10k, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debitsOver10k, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debits10k, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits10k, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
       EligibilityService.runEligibilityCheck(EligibilityRequest(beforeTaxYearStart,
-                                                                createTaxpayer(debitsUnder10k, returns)), true) shouldBe Eligible
+                                                                createReturnsAndDebits(debitsUnder10k, returns)), true) shouldBe Eligible
     }
 
     "SA Return not yet submitted by customer" in {
@@ -189,7 +189,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 1, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     "SA Return submitted in future by customer" in {
@@ -205,7 +205,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 1, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     "Return submitted, total amount > £10k" in {
@@ -221,7 +221,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 12, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
     }
 
     "Return submitted, debt > £32 is older than 29 days" in {
@@ -237,7 +237,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 12, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
     }
 
     "Return submitted, old debt < £32, total amount < £10k" in {
@@ -254,7 +254,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 12, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Eligible
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Eligible
     }
 
     "Return submitted, old returns overdue" in {
@@ -274,7 +274,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 12, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     "Return submitted, total amount <£10k" in {
@@ -290,7 +290,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2017, 2, 4)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Eligible
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Eligible
     }
 
     "Return submitted, total amount >£10k with future liability" in {
@@ -306,7 +306,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2017, 2, 4)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(TotalDebtIsTooHigh))
     }
 
     "Return submitted, old debts > £32" in {
@@ -324,7 +324,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2016, 12, 31)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(OldDebtIsTooHigh))
     }
 
     "Return submitted, total liability > £32" in {
@@ -338,7 +338,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2017, 7, 10)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), true) shouldBe Ineligible(List(DebtIsInsignificant))
+                                                                createReturnsAndDebits(debits, returns)), true) shouldBe Ineligible(List(DebtIsInsignificant))
     }
 
     "Return submitted, utr not on ia " in {
@@ -352,7 +352,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val todaysDate = LocalDate.of(2017, 7, 10)
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(todaysDate,
-                                                                createTaxpayer(debits, returns)), false) shouldBe Ineligible(List(IsNotOnIa))
+                                                                createReturnsAndDebits(debits, returns)), false) shouldBe Ineligible(List(IsNotOnIa))
     }
   }
 
@@ -391,7 +391,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
     Address(Some("1 Donut Street"), Some("Balaxian Waystation"), Some("Algaranius Cluster"), Some("Becolian Sector"), Some("Andromeda Galaxy"), Some("BN1 1AA"))
   }
 
-  private def createTaxpayer(debits: Seq[Debit], returns: Seq[Return]) = {
-    Taxpayer(selfAssessment = SelfAssessmentDetails(debits                   = debits, returns = returns, communicationPreferences = CommunicationPreferences(true, true, true, true), utr = SaUtr("6573196998")), customerName = "Mr Eric Biddle", addresses = Seq(address))
+  private def createReturnsAndDebits(debits: Seq[Debit], returns: Seq[Return]) = {
+    ReturnsAndDebits(debits  = debits, returns = returns)
   }
 }

--- a/test/pagespecs/AccessibilityStatementPageSpec.scala
+++ b/test/pagespecs/AccessibilityStatementPageSpec.scala
@@ -23,7 +23,7 @@ class AccessibilityStatementPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/ArrangementSummaryPageSpec.scala
+++ b/test/pagespecs/ArrangementSummaryPageSpec.scala
@@ -26,7 +26,7 @@ class ArrangementSummaryPageSpec extends ItSpec {
 
   def beginJourney(): StubMapping = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/CalculatorInstalmentsPageSpec.scala
+++ b/test/pagespecs/CalculatorInstalmentsPageSpec.scala
@@ -24,7 +24,7 @@ class CalculatorInstalmentsPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/CalculatorTaxLiabilitiesPageSpec.scala
+++ b/test/pagespecs/CalculatorTaxLiabilitiesPageSpec.scala
@@ -24,7 +24,7 @@ class CalculatorTaxLiabilitiesPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/DirectDebitConfirmationPageSpec.scala
+++ b/test/pagespecs/DirectDebitConfirmationPageSpec.scala
@@ -25,7 +25,7 @@ class DirectDebitConfirmationPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/DirectDebitPageSpec.scala
+++ b/test/pagespecs/DirectDebitPageSpec.scala
@@ -26,7 +26,7 @@ class DirectDebitPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/IneligiblePagesSpec.scala
+++ b/test/pagespecs/IneligiblePagesSpec.scala
@@ -53,7 +53,7 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
 
   def beginJourney(ineligibleReason: Reason): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer(ineligibleReason)
+    TaxpayerStub.getReturnsAndDebits(ineligibleReason)
     if (ineligibleReason == IsNotOnIa) IaStub.failedIaCheck
     else IaStub.successfulIaCheck
     GgStub.signInPage(port)
@@ -74,7 +74,7 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
   "authorisation based eligibility" - {
     "show not-enrolled page for confidence level < 200" in {
       AuthStub.authorise(confidenceLevel = Some(L100))
-      TaxpayerStub.getTaxpayer()
+      TaxpayerStub.getReturnsAndDebits()
       GgStub.signInPage(port)
       startPage.open()
       startPage.clickOnStartNowButton()
@@ -82,7 +82,7 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
     }
     "show not-enrolled page no sa enrolments" in {
       AuthStub.authorise(allEnrolments = Some(Set()))
-      TaxpayerStub.getTaxpayer()
+      TaxpayerStub.getReturnsAndDebits()
       GgStub.signInPage(port)
       startPage.open()
       startPage.clickOnStartNowButton()
@@ -90,7 +90,7 @@ class IneligiblePagesSpec extends ItSpec with TableDrivenPropertyChecks {
     }
     "show not-enrolled page when the user has no activated sa enrolments" in {
       AuthStub.authorise(allEnrolments = Some(Set(unactivatedSaEnrolment)))
-      TaxpayerStub.getTaxpayer()
+      TaxpayerStub.getReturnsAndDebits()
       GgStub.signInPage(port)
       startPage.open()
       startPage.clickOnStartNowButton()

--- a/test/pagespecs/InstalmentSummaryPageSpec.scala
+++ b/test/pagespecs/InstalmentSummaryPageSpec.scala
@@ -24,7 +24,7 @@ class InstalmentSummaryPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/InstalmentSummarySelectDatePageSpec.scala
+++ b/test/pagespecs/InstalmentSummarySelectDatePageSpec.scala
@@ -24,7 +24,7 @@ class InstalmentSummarySelectDatePageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/MonthlyPaymentAmountPageSpec.scala
+++ b/test/pagespecs/MonthlyPaymentAmountPageSpec.scala
@@ -24,7 +24,7 @@ class MonthlyPaymentAmountPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/PaymentSummaryPageSpec.scala
+++ b/test/pagespecs/PaymentSummaryPageSpec.scala
@@ -24,7 +24,7 @@ class PaymentSummaryPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/PaymentTodayCalculatorPageSpec.scala
+++ b/test/pagespecs/PaymentTodayCalculatorPageSpec.scala
@@ -23,7 +23,7 @@ import testsupport.stubs.{AuthStub, GgStub, IaStub, TaxpayerStub}
 class PaymentTodayCalculatorPageSpec extends ItSpec {
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/PaymentTodayQuestionPageSpec.scala
+++ b/test/pagespecs/PaymentTodayQuestionPageSpec.scala
@@ -24,7 +24,7 @@ class PaymentTodayQuestionPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/pagespecs/StartPageSpec.scala
+++ b/test/pagespecs/StartPageSpec.scala
@@ -50,7 +50,7 @@ class StartPageSpec extends ItSpec {
 
   "eligible" in {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
 
     GgStub.signInPage(port)
@@ -61,7 +61,7 @@ class StartPageSpec extends ItSpec {
 
   "not eligible (debt too large)" in {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer(TotalDebtIsTooHigh)
+    TaxpayerStub.getReturnsAndDebits(TotalDebtIsTooHigh)
     IaStub.successfulIaCheck
 
     startPage.open()

--- a/test/pagespecs/TermsAndConditionsPageSpec.scala
+++ b/test/pagespecs/TermsAndConditionsPageSpec.scala
@@ -25,7 +25,7 @@ class TermsAndConditionsPageSpec extends ItSpec {
 
   def beginJourney(): Unit = {
     AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
+    TaxpayerStub.getReturnsAndDebits()
     IaStub.successfulIaCheck
     GgStub.signInPage(port)
     startPage.open()

--- a/test/ssttpcalculator/CalculatorControllerSpec.scala
+++ b/test/ssttpcalculator/CalculatorControllerSpec.scala
@@ -26,7 +26,7 @@ import testsupport.ItSpec
 import testsupport.stubs.CalculatorStub._
 import testsupport.testdata.TdAll.saUtr
 import timetopaycalculator.cor.model.PaymentSchedule
-import timetopaytaxpayer.cor.model.{CommunicationPreferences, Return, SelfAssessmentDetails}
+import timetopaytaxpayer.cor.model.{CommunicationPreferences, Return, ReturnsAndDebits, SelfAssessmentDetails}
 import uk.gov.hmrc.http.HeaderCarrier
 
 class CalculatorControllerSpec extends ItSpec {
@@ -81,7 +81,7 @@ class CalculatorControllerSpec extends ItSpec {
     private val testReturns = List(Return(taxReturnDate, None, Some(taxReturnDate), None))
     private val communicationPreferences = CommunicationPreferences(
       welshLanguageIndicator = true, audioIndicator = true, largePrintIndicator = true, brailleIndicator = true)
-    private val selfAssessmentDetails = SelfAssessmentDetails(saUtr, communicationPreferences, Nil, testReturns)
+    private val returnsAndDebits = ReturnsAndDebits(Nil, testReturns)
 
     private val twoMonthSchedule = paymentSchedules.find(_.firstInstallment.amount == twoMonthScheduleRegularPaymentAmount).head
     private val threeMonthSchedule = paymentSchedules.find(_.firstInstallment.amount == threeMonthScheduleRegularPaymentAmount).head
@@ -91,15 +91,15 @@ class CalculatorControllerSpec extends ItSpec {
     private val sevenMonthSchedule = paymentSchedules.find(_.firstInstallment.amount == sevenMonthScheduleRegularPaymentAmount).head
 
     private val closestSchedulesToTwoMonthSchedule =
-      controller.closestSchedules(twoMonthSchedule, paymentSchedules, selfAssessmentDetails)(FakeRequest()).toSet
+      controller.closestSchedules(twoMonthSchedule, paymentSchedules, returnsAndDebits)(FakeRequest()).toSet
     closestSchedulesToTwoMonthSchedule shouldBe Set(twoMonthSchedule, threeMonthSchedule, fourMonthSchedule)
 
     private val closestSchedulesToSixMonthSchedule =
-      controller.closestSchedules(sixMonthSchedule, paymentSchedules, selfAssessmentDetails)(FakeRequest()).toSet
+      controller.closestSchedules(sixMonthSchedule, paymentSchedules, returnsAndDebits)(FakeRequest()).toSet
     closestSchedulesToSixMonthSchedule shouldBe Set(fiveMonthSchedule, sixMonthSchedule, sevenMonthSchedule)
 
     private val closestSchedulesToSevenMonthSchedule =
-      controller.closestSchedules(sevenMonthSchedule, paymentSchedules, selfAssessmentDetails)(FakeRequest()).toSet
+      controller.closestSchedules(sevenMonthSchedule, paymentSchedules, returnsAndDebits)(FakeRequest()).toSet
     closestSchedulesToSevenMonthSchedule shouldBe Set(fiveMonthSchedule, sixMonthSchedule, sevenMonthSchedule)
   }
 }

--- a/test/ssttpcalculator/CalculatorServiceSpec.scala
+++ b/test/ssttpcalculator/CalculatorServiceSpec.scala
@@ -51,25 +51,25 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
   private val communicationPreferences = CommunicationPreferences(
     welshLanguageIndicator = true, audioIndicator = true, largePrintIndicator = true, brailleIndicator = true)
 
-  private val sa = SelfAssessmentDetails(SaUtr("123456789"), communicationPreferences, Nil, List(return2016))
+  private val returnsAndDebits = ReturnsAndDebits(Nil, List(return2016))
 
   //Note the calculator logic is not responsible for determining eligibility
   private val scenariosBasedAroundJanuaryDuedate = Table(
     ("todayDate", "self assessment", "expected answer"),
     //Customer 1
-    (startDate, sa.copy(debits = List(
+    (startDate, returnsAndDebits.copy(debits = List(
       debit("BCD", "2016-04-05", 1000, "2017-01-31"),
       debit("POA1", "2016-04-05", 2000, "2017-01-31"),
       debit("POA2", "2016-04-05", 2000, "2017-01-31"))), 11),
 
     //Customer 2
-    (startDate.withMonth(2).withDayOfMonth(14), sa.copy(debits = List(
+    (startDate.withMonth(2).withDayOfMonth(14), returnsAndDebits.copy(debits = List(
       debit("BCD", "2016-04-05", 1000, "2017-01-31"),
       debit("POA1", "2016-04-05", 3000, "2017-01-31", Some(40)),
       debit("POA2", "2016-04-05", 3000, "2017-07-31"))), 10),
 
     // Customer 4
-    (startDate.withMonth(1).withDayOfMonth(10), sa.copy(debits = List(
+    (startDate.withMonth(1).withDayOfMonth(10), returnsAndDebits.copy(debits = List(
       debit("BCD", "2016-04-05", 1000, "2017-01-31"),
       debit("POA1", "2016-04-05", 3000, "2017-01-31", Some(40)),
       debit("POA2", "2016-04-05", 3000, "2017-07-31"),
@@ -79,33 +79,33 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
   private val scenariosBasedAroundJulyDuedate = Table(
     ("todayDate", "self assessment", "expected answer"),
     //Customer 9
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(debits = List(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(debits = List(
       debit("POA2", "2016-04-05", 5000, "2017-07-31"))), 5),
     //Customer 10
-    (startDate.withMonth(8).withDayOfMonth(14), sa.copy(debits = List(
+    (startDate.withMonth(8).withDayOfMonth(14), returnsAndDebits.copy(debits = List(
       debit("POA2", "2016-04-05", 3000, "2017-07-31", Some(20)))), 4),
     //Customer 11
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(debits = List(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(debits = List(
       debit("POA2", "2016-04-05", 3000, "2017-07-31"),
       debit("Interest from previous arrangement", "2015-04-05", 28, "2016-01-31"))), 5),
     //Customer 13
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(debits = List(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(debits = List(
       debit("POA2", "2016-04-05", 3000, "2017-07-31"))), 5))
 
   private val scenariosBasedAroundEarlyFilers = Table(
     ("todayDate", "self assessment", "expected answer"),
     //Customer 15
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(
       debits  = List(debit("POA2", "2016-04-05", 5000, "2017-07-31")),
       returns = List(return2016, return2017)), 11),
     //Customer 16
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(
       debits  = List(
         debit("POA2", "2016-04-05", 5000, "2017-07-31"),
         debit("BCD", "2017-04-05", 2000, "2018-01-18")),
       returns = List(return2016, return2017)), 11),
     //Customer 17
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(
       debits  = List(
         debit("POA2", "2016-04-05", 5000, "2017-07-31"),
         debit("BCD", "2017-04-05", 2000, "2018-01-31"),
@@ -113,7 +113,7 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
         debit("POA2", "2017-04-05", 1000, "2018-01-31")),
       returns = List(return2016, return2017)), 11),
     //Customer 19
-    (startDate.withMonth(5).withDayOfMonth(1), sa.copy(
+    (startDate.withMonth(5).withDayOfMonth(1), returnsAndDebits.copy(
       debits  = List(
         debit("BCD", "2017-04-05", 1000, "2018-01-31"),
         debit("POA1", "2017-04-05", 2000, "2018-01-31"),
@@ -125,32 +125,32 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
     ("todayDate", "self assessment", "expected answer"),
     //Customer 20
     //todo I am assuming the old charges will not appear in des?
-    (startDate.withMonth(7).withDayOfMonth(1), sa.copy(
+    (startDate.withMonth(7).withDayOfMonth(1), returnsAndDebits.copy(
       debits  = List(
         debit("BCD", "2017-04-05", 0, "2017-07-31"),
         debit("Late payment penalty", "2015-04-05", 1000, "2017-04-28")),
       returns = List(return2016, return2017)), 11),
     //Customer 21
     //todo will the Late payment penalty appear as two paymeant
-    (startDate.withMonth(4).withDayOfMonth(20), sa.copy(
+    (startDate.withMonth(4).withDayOfMonth(20), returnsAndDebits.copy(
       debits  = List(
         debit("BCD", "2017-04-05", 0, "2017-07-31"),
         debit("Late payment penalty", "2016-04-05", 1000, "2017-04-28"),
         debit("POA2", "2016-04-05", 5000, "2017-07-17")),
       returns = List(return2016, return2017)), 11),
     //Customer 22
-    (startDate.withMonth(3).withDayOfMonth(20), sa.copy(
+    (startDate.withMonth(3).withDayOfMonth(20), returnsAndDebits.copy(
       debits  = List(
         debit("Late payment penalty", "2016-04-05", 100, "2017-03-25")),
       returns = List(return2016, return2017)), 11),
     //Customer 24
-    (startDate.withMonth(3).withDayOfMonth(20), sa.copy(
+    (startDate.withMonth(3).withDayOfMonth(20), returnsAndDebits.copy(
       debits  = List(
         debit("POA2", "2016-04-05", 3000, "2017-07-31"),
         debit("Late payment penalty", "2016-04-05", 100, "2017-03-17")),
       returns = List(return2016, return2017)), 11),
     //Customer 25
-    (startDate.withMonth(11).withDayOfMonth(20), sa.copy(
+    (startDate.withMonth(11).withDayOfMonth(20), returnsAndDebits.copy(
       debits  = List(
         debit("Late payment penalty", "2016-04-05", 100, "2016-12-16"),
         debit("BCD", "2016-04-05", 50, "2017-01-31"),
@@ -161,7 +161,7 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
 
   private val scenariosBasedCustom = Table(
     ("todayDate", "self assessment", "expected answer"),
-    (startDate.withMonth(12).withDayOfMonth(18), sa.copy(
+    (startDate.withMonth(12).withDayOfMonth(18), returnsAndDebits.copy(
       debits  = List(
         debit("IN1", "2018-04-05", 30, "2018-01-31"),
         debit("IN2", "2018-04-05", 500, "2018-07-31")),
@@ -169,18 +169,18 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
 
   //todo ask ela about 11 13 15
   "CalculatorLogic" should {
-    TableDrivenPropertyChecks.forAll(scenariosBasedAroundJanuaryDuedate) { (startDate: LocalDate, selfA: SelfAssessmentDetails, answer: Int) =>
-      s"scenarios Based Around January Due date return the correct number of months($answer) for start date : $startDate and SelfAssessmentDetails $selfA" in {
-        val result: Int = maximumDurationInMonths(selfA, startDate)
+    TableDrivenPropertyChecks.forAll(scenariosBasedAroundJanuaryDuedate) { (startDate: LocalDate, returnsAndDebits: ReturnsAndDebits, answer: Int) =>
+      s"scenarios Based Around January Due date return the correct number of months($answer) for start date : $startDate and ReturnsAndDebits $returnsAndDebits" in {
+        val result: Int = maximumDurationInMonths(returnsAndDebits, startDate)
         assert(result == answer)
       }
     }
   }
 
   "CalculatorLogic" should {
-    TableDrivenPropertyChecks.forAll(scenariosBasedAroundJulyDuedate) { (startDate: LocalDate, selfA: SelfAssessmentDetails, answer: Int) =>
-      s"scenarios Based Around July Due date return the correct number of months($answer) for start date : $startDate and SelfAssessmentDetails $selfA" in {
-        val result: Int = maximumDurationInMonths(selfA, startDate)
+    TableDrivenPropertyChecks.forAll(scenariosBasedAroundJulyDuedate) { (startDate: LocalDate, returnsAndDebits: ReturnsAndDebits, answer: Int) =>
+      s"scenarios Based Around July Due date return the correct number of months($answer) for start date : $startDate and ReturnsAndDebits $returnsAndDebits" in {
+        val result: Int = maximumDurationInMonths(returnsAndDebits, startDate)
         assert(result == answer)
 
       }
@@ -188,27 +188,27 @@ class CalculatorServiceSpec extends PlaySpec with TableDrivenPropertyChecks {
   }
 
   "CalculatorLogic" should {
-    TableDrivenPropertyChecks.forAll(scenariosBasedAroundEarlyFilers) { (startDate: LocalDate, selfA: SelfAssessmentDetails, answer: Int) =>
-      s"scenarios Based Around Early Filers Due date return the correct number of months($answer) for start date : $startDate and SelfAssessmentDetails $selfA" in {
-        val result: Int = maximumDurationInMonths(selfA, startDate)
+    TableDrivenPropertyChecks.forAll(scenariosBasedAroundEarlyFilers) { (startDate: LocalDate, returnsAndDebits: ReturnsAndDebits, answer: Int) =>
+      s"scenarios Based Around Early Filers Due date return the correct number of months($answer) for start date : $startDate and ReturnsAndDebits $returnsAndDebits" in {
+        val result: Int = maximumDurationInMonths(returnsAndDebits, startDate)
         assert(result == answer)
       }
     }
   }
 
   "CalculatorLogic" should {
-    TableDrivenPropertyChecks.forAll(scenariosBasedAroundEarlyFilers) { (startDate: LocalDate, selfA: SelfAssessmentDetails, answer: Int) =>
-      s"scenarios Based Around Late Filers Due date return the correct number of months($answer) for start date : $startDate and SelfAssessmentDetails $selfA" in {
-        val result: Int = maximumDurationInMonths(selfA, startDate)
+    TableDrivenPropertyChecks.forAll(scenariosBasedAroundEarlyFilers) { (startDate: LocalDate, returnsAndDebits: ReturnsAndDebits, answer: Int) =>
+      s"scenarios Based Around Late Filers Due date return the correct number of months($answer) for start date : $startDate and ReturnsAndDebits $returnsAndDebits" in {
+        val result: Int = maximumDurationInMonths(returnsAndDebits, startDate)
         assert(result == answer)
       }
     }
   }
 
   "CalculatorLogic" should {
-    TableDrivenPropertyChecks.forAll(scenariosBasedCustom) { (startDate: LocalDate, selfA: SelfAssessmentDetails, answer: Int) =>
-      s"scenarios Based Around Custom the correct number of months($answer) for start date : $startDate and SelfAssessmentDetails $selfA" in {
-        val result: Int = maximumDurationInMonths(selfA, startDate)
+    TableDrivenPropertyChecks.forAll(scenariosBasedCustom) { (startDate: LocalDate, returnsAndDebits: ReturnsAndDebits, answer: Int) =>
+      s"scenarios Based Around Custom the correct number of months($answer) for start date : $startDate and ReturnsAndDebits $returnsAndDebits" in {
+        val result: Int = maximumDurationInMonths(returnsAndDebits, startDate)
         assert(result == answer)
       }
     }

--- a/test/testsupport/stubs/TaxpayerStub.scala
+++ b/test/testsupport/stubs/TaxpayerStub.scala
@@ -23,16 +23,16 @@ import org.scalatest.Matchers
 import play.api.http.Status
 import play.api.libs.json.Json.{prettyPrint, toJson}
 import testsupport.testdata.EligibilityTaxpayerVariationsTd._
-import testsupport.testdata.TdAll.{taxpayer, utr}
+import testsupport.testdata.TdAll.{returnsAndDebits, utr}
 import uk.gov.hmrc.selfservicetimetopay.models._
 
 object TaxpayerStub extends Matchers with Status {
-  private val url: UrlPathPattern = urlPathEqualTo(s"/taxpayer/$utr")
+  private val url: UrlPathPattern = urlPathEqualTo(s"/taxpayer/returns-and-debits/$utr")
 
-  def getTaxpayer(): StubMapping =
-    stubFor(get(url).willReturn(aResponse().withStatus(OK).withBody(prettyPrint(toJson(taxpayer)))))
+  def getReturnsAndDebits(): StubMapping =
+    stubFor(get(url).willReturn(aResponse().withStatus(OK).withBody(prettyPrint(toJson(returnsAndDebits)))))
 
-  def getTaxpayer(reason: Reason): StubMapping =
+  def getReturnsAndDebits(reason: Reason): StubMapping =
     stubFor(get(url).willReturn(aResponse()
       .withStatus(OK)
       .withBody(prettyPrint(toJson(getIneligibleTaxpayerModel(reason))))))

--- a/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
+++ b/test/testsupport/testdata/EligibilityTaxpayerVariationsTd.scala
@@ -18,7 +18,6 @@ package testsupport.testdata
 
 import java.time.LocalDate
 
-import testsupport.testdata.TdAll.{communicationPreferences, saUtr}
 import timetopaytaxpayer.cor.model._
 import uk.gov.hmrc.selfservicetimetopay.models._
 
@@ -31,28 +30,19 @@ object EligibilityTaxpayerVariationsTd {
   private def debit(amount: Double, dueDate: LocalDate) =
     Debit("IN1", BigDecimal(amount), dueDate, Some(Interest(Some(dummyCurrentDate), BigDecimal(0))), dummyTaxYearEnd)
 
-  private def taxpayer(debits: Seq[Debit], returns: Seq[Return] = Seq.empty) =
-    Taxpayer(
-      "The Emperor Of Mankind",
-      Seq(Address(
-        Some("Golden Throne"),
-        Some("Himalayan Mountains"),
-        Some("Holy Terra"),
-        Some("Segmentum Solar"),
-        Some("Milky Way Galaxy"),
-        Some("BN11 1XX"))),
-      SelfAssessmentDetails(saUtr, communicationPreferences, debits, returns))
+  private def returnsAndDebits(debits: Seq[Debit] = Seq.empty, returns: Seq[Return] = Seq.empty) =
+    ReturnsAndDebits(debits, returns)
 
-  def getIneligibleTaxpayerModel(reason: Reason): Taxpayer = {
+  def getIneligibleTaxpayerModel(reason: Reason): ReturnsAndDebits = {
     reason match {
-      case NoDebt              => taxpayer(Seq.empty)
-      case DebtIsInsignificant => taxpayer(Seq(debit(31, dummyCurrentDate)))
-      case OldDebtIsTooHigh    => taxpayer(Seq(debit(33, dummy60DaysAgo)))
-      case TotalDebtIsTooHigh  => taxpayer(Seq(debit(10000, dummyCurrentDate)))
+      case NoDebt              => returnsAndDebits(Seq.empty)
+      case DebtIsInsignificant => returnsAndDebits(Seq(debit(31, dummyCurrentDate)))
+      case OldDebtIsTooHigh    => returnsAndDebits(Seq(debit(33, dummy60DaysAgo)))
+      case TotalDebtIsTooHigh  => returnsAndDebits(Seq(debit(10000, dummyCurrentDate)))
       case ReturnNeedsSubmitting =>
-        taxpayer(eligibleDebits, Seq(Return(dummyTaxYearEnd, Some(dummy60DaysAgo), Some(dummyCurrentDate), None)))
-      case IsNotOnIa => taxpayer(eligibleDebits)
-      case _         => TdAll.taxpayer
+        returnsAndDebits(eligibleDebits, Seq(Return(dummyTaxYearEnd, Some(dummy60DaysAgo), Some(dummyCurrentDate), None)))
+      case IsNotOnIa => returnsAndDebits(eligibleDebits)
+      case _         => TdAll.returnsAndDebits
     }
   }
 }

--- a/test/testsupport/testdata/TdAll.scala
+++ b/test/testsupport/testdata/TdAll.scala
@@ -67,17 +67,12 @@ object TdAll {
     addressLine5 = None,
     postcode     = Some("BN12 4XL"))
 
-  val taxpayer =
-    Taxpayer(
-      "Mr John Campbell",
-      List(address),
-      SelfAssessmentDetails(
-        saUtr,
-        communicationPreferences,
-        List(debit1, debit2),
-        List(
-          Return(taxYearEnd, issuedDate = "2019-11-10", dueDate = "2019-08-15", receivedDate = "2019-03-09"),
-          Return(taxYearEnd   = "2018-04-05", issuedDate = "2017-02-15", dueDate = "2018-01-31", receivedDate = "2018-03-09"))))
+  val returnsAndDebits =
+    ReturnsAndDebits(
+      List(debit1, debit2),
+      List(
+        Return(taxYearEnd, issuedDate = "2019-11-10", dueDate = "2019-08-15", receivedDate = "2019-03-09"),
+        Return(taxYearEnd   = "2018-04-05", issuedDate = "2017-02-15", dueDate = "2018-01-31", receivedDate = "2018-03-09")))
 
   val saEnrolment = Enrolment(
     key               = "IR-SA", identifiers = List(EnrolmentIdentifier("UTR", utr)), state = "Activated", delegatedAuthRule = None)


### PR DESCRIPTION
-Update to work with the new version of ssttp-taxpayer
-Changes the Taxpayer model to be replaced by ReturnsAndDebits in order to avoid unnecessarily passing around PII
-needs https://github.com/hmrc/time-to-pay-taxpayer/pull/31/files
-https://jira.tools.tax.service.gov.uk/browse/OPS-4163x