### PR TITLE
ET-OPS-4768-change-to-eligibility-assessment

### DIFF
--- a/app/ssttpeligibility/EligibilityService.scala
+++ b/app/ssttpeligibility/EligibilityService.scala
@@ -56,10 +56,10 @@ object EligibilityService {
     (0 to returnHistoryYearsRequired).reverse
       .map(currentTaxYearEndDate.getYear - _)
       .map(year => returnDateForCalendarYear(year))
-      .flatMap(returnDateForYear => checkReturnHasBeenReceived(returnDateForYear, returns, today)).toList
+      .flatMap(returnDateForYear => checkReturn(returnDateForYear, returns, today)).toList
   }
 
-  private def checkReturnHasBeenReceived(taxYearEnd: LocalDate, returns: Seq[Return], today: LocalDate): Option[Reason] = {
+  private def checkReturn(taxYearEnd: LocalDate, returns: Seq[Return], today: LocalDate): Option[Reason] = {
     returns.find(_.taxYearEnd == taxYearEnd) match {
       //To match and return a reason for ineligibility the following needs to be true:
       //The issued date needs to be today or earlier, which means we have informed them

--- a/app/ssttpeligibility/EligibilityService.scala
+++ b/app/ssttpeligibility/EligibilityService.scala
@@ -144,12 +144,6 @@ object EligibilityService {
   }
 
   private def isDatePresentAndAfterToday(today: LocalDate, dateOption: Option[LocalDate]): Boolean = {
-    dateOption match {
-      case Some(date: LocalDate) =>
-        if (date.isAfter(today)) true
-        else false
-      case _ =>
-        false
-    }
+    dateOption.exists(_.isAfter(today))
   }
 }

--- a/test/eligibility/EligibilityServiceSpec.scala
+++ b/test/eligibility/EligibilityServiceSpec.scala
@@ -67,7 +67,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
       val debts = Seq(charge(200, afterTaxYearStart))
 
       EligibilityService.runEligibilityCheck(EligibilityRequest(afterTaxYearStart,
-                                                                createTaxpayer(debts, returns)), true) shouldBe Eligible
+                                                                createTaxpayer(debts, returns)), true) shouldBe Ineligible(List(ReturnNeedsSubmitting))
     }
 
     """not grant eligibility if all returns are filed except the most recent which is still outstanding and has a missing due date
@@ -375,7 +375,7 @@ class EligibilityServiceSpec extends WordSpecLike with GuiceOneAppPerSuite with 
   }
 
   val outstandingReturnThisYearButNotOverdue = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)), dueDate = Some(LocalDate.of(2017, 7, 11)))
-  val outstandingReturnThisYearAndOverdue = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)), dueDate = Some(LocalDate.of(2017, 7, 1)))
+  val outstandingReturnThisYearAndOverdue = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)), dueDate = Some(LocalDate.of(2016, 2, 1)))
   val outstandingReturnThisYearWithMissingDueDate = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)), dueDate = None)
   val overdueReturnThisYear = Return(taxYearEnd = LocalDate.of(2016, 4, 5), issuedDate = Some(LocalDate.of(2015, 3, 6)))
   val lastThreeCalendarYears: Seq[Int] = Seq(2013, 2014, 2015)


### PR DESCRIPTION
-users will now be eligible if they have a return for this year that has not been received but is not overdue.