### PR TITLE
[MP][OPS-5656] override Journey#toString so that PII isnt leaked

### DIFF
--- a/app/journey/Journey.scala
+++ b/app/journey/Journey.scala
@@ -21,7 +21,6 @@ import enumeratum.{Enum, EnumEntry}
 import enumformat.EnumFormat
 import journey.Statuses.{FinishedApplicationSuccessful, InProgress}
 import play.api.libs.json.{Format, Json, OFormat}
-import ssttpcalculator.model.{CalculatorInput, PaymentSchedule}
 import timetopaytaxpayer.cor.model.{Debit, Taxpayer}
 import uk.gov.hmrc.selfservicetimetopay.models.{CalculatorDuration, _}
 
@@ -84,35 +83,35 @@ final case class Journey(
   def debits: Seq[Debit] = taxpayer.selfAssessment.debits
 
   def requireIsInProgress(): Unit = {
-    require(status == InProgress, s"status has to be InProgress [${this.obfuscate}]")
+    require(status == InProgress, s"status has to be InProgress [${this}]")
   }
   def requireIsEligible(): Unit = {
-    require(eligibilityStatus.eligible, s"taxpayer has to be eligible [${this.obfuscate}]")
+    require(eligibilityStatus.eligible, s"taxpayer has to be eligible [${this}]")
   }
 
   def requireScheduleIsDefined(): Unit = {
     requireIsInProgress()
     requireIsEligible()
 
-    require(maybeTaxpayer.isDefined, s"'taxpayer' has to be defined at this stage of a journey [${this.obfuscate}]")
-    require(maybePaymentToday.isDefined, s"'maybePaymentToday' has to be defined at this stage of a journey [${this.obfuscate}]")
-    require(maybeMonthlyPaymentAmount.isDefined, s"'maybeMonthlyPaymentAmount' has to be defined at this stage of a journey [${this.obfuscate}]")
-    require(maybeCalculatorDuration.isDefined, s"'maybeCalculatorDuration' has to be defined at this stage of a journey [${this.obfuscate}]")
-    require(maybeArrangementDayOfMonth.isDefined, s"'maybeArrangementDayOfMonth' has to be defined at this stage of a journey [${this.obfuscate}]")
+    require(maybeTaxpayer.isDefined, s"'taxpayer' has to be defined at this stage of a journey [${this}]")
+    require(maybePaymentToday.isDefined, s"'maybePaymentToday' has to be defined at this stage of a journey [${this}]")
+    require(maybeMonthlyPaymentAmount.isDefined, s"'maybeMonthlyPaymentAmount' has to be defined at this stage of a journey [${this}]")
+    require(maybeCalculatorDuration.isDefined, s"'maybeCalculatorDuration' has to be defined at this stage of a journey [${this}]")
+    require(maybeArrangementDayOfMonth.isDefined, s"'maybeArrangementDayOfMonth' has to be defined at this stage of a journey [${this}]")
   }
 
   def requireDdIsDefined(): Unit = {
     requireScheduleIsDefined()
-    require(maybeBankDetails.isDefined, s"'maybeBankDetails' has to be defined at this stage of a journey [${this.obfuscate}]")
+    require(maybeBankDetails.isDefined, s"'maybeBankDetails' has to be defined at this stage of a journey [${this}]")
   }
 
-  def paymentToday: Boolean = maybePaymentToday.map(_.value).getOrElse(throw new RuntimeException(s"Expected 'maybePaymentToday' to be there but was not found. [${_id}] [${this.obfuscate}]"))
-  def initialPayment: BigDecimal = maybePaymentTodayAmount.map(_.value).getOrElse(throw new RuntimeException(s"Expected 'paymentTodayAmount' to be there but was not found. [${_id}] [${this.obfuscate}]"))
+  def paymentToday: Boolean = maybePaymentToday.map(_.value).getOrElse(throw new RuntimeException(s"Expected 'maybePaymentToday' to be there but was not found. [${_id}] [${this}]"))
+  def initialPayment: BigDecimal = maybePaymentTodayAmount.map(_.value).getOrElse(throw new RuntimeException(s"Expected 'paymentTodayAmount' to be there but was not found. [${_id}] [${this}]"))
   def safeInitialPayment: BigDecimal = maybePaymentTodayAmount.map(_.value).getOrElse(0)
-  def calculatorDuration: Int = maybeCalculatorDuration.map(_.chosenMonths).getOrElse(throw new RuntimeException(s"Expected 'maybeCalculatorDuration' to be there but was not found. [${_id}] [${this.obfuscate}]"))
+  def calculatorDuration: Int = maybeCalculatorDuration.map(_.chosenMonths).getOrElse(throw new RuntimeException(s"Expected 'maybeCalculatorDuration' to be there but was not found. [${_id}] [${this}]"))
 
   def eligibilityStatus: EligibilityStatus =
-    maybeEligibilityStatus.getOrElse(throw new RuntimeException(s"Expected 'EligibilityStatus' to be there but was not found. [${_id}] [${this.obfuscate}]"))
+    maybeEligibilityStatus.getOrElse(throw new RuntimeException(s"Expected 'EligibilityStatus' to be there but was not found. [${_id}] [${this}]"))
 
   def arrangementDirectDebit: Option[ArrangementDirectDebit] = maybeBankDetails.map(f => ArrangementDirectDebit.from(f))
 
@@ -135,6 +134,10 @@ final case class Journey(
     ddRef                     = ddRef.map(_ => "***"),
     maybeSaUtr                = maybeSaUtr.map(_ => "***")
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object Journey {

--- a/app/journey/JourneyService.scala
+++ b/app/journey/JourneyService.scala
@@ -49,7 +49,7 @@ class JourneyService @Inject() (journeyRepo: JourneyRepo)(implicit ec: Execution
   def getEligibleJourneyInProgress()(implicit request: Request[_]): Future[Journey] = Mdc.preservingMdc {
     getJourney().map {
       case j: Journey if j.status == InProgress && j.maybeEligibilityStatus.isDefined && j.eligibilityStatus.eligible => j
-      case j => throw new RuntimeException(s"Expected eligible journey in progress [${j.obfuscate}]")
+      case j => throw new RuntimeException(s"Expected eligible journey in progress [${j}]")
     }
   }
 

--- a/app/ssttpcalculator/CalculatorService.scala
+++ b/app/ssttpcalculator/CalculatorService.scala
@@ -64,7 +64,7 @@ class CalculatorService @Inject() (
       .orElse(
         availableSchedules.find(_.instalments.length == durationInMonths - 1)
       ).getOrElse(
-          throw new RuntimeException(s"Could not find schedule corresponding to $durationInMonths [${journey.obfuscate}] [${availableSchedules}]")
+          throw new RuntimeException(s"Could not find schedule corresponding to $durationInMonths [${journey}] [${availableSchedules}]")
         )
     schedule
   }

--- a/app/ssttpdirectdebit/DirectDebitController.scala
+++ b/app/ssttpdirectdebit/DirectDebitController.scala
@@ -86,7 +86,7 @@ class DirectDebitController @Inject() (
       journey.requireScheduleIsDefined()
       journey.requireDdIsDefined()
       val schedule = calculatorService.computeSchedule(journey)
-      val directDebit = journey.arrangementDirectDebit.getOrElse(throw new RuntimeException(s"arrangement direct debit not found on submission [${journey.obfuscate}]"))
+      val directDebit = journey.arrangementDirectDebit.getOrElse(throw new RuntimeException(s"arrangement direct debit not found on submission [${journey}]"))
       Future.successful(Ok(views.direct_debit_confirmation(
         journey.taxpayer.selfAssessment.debits, schedule, directDebit, isSignedIn))
       )

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/BankDetails.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/BankDetails.scala
@@ -27,6 +27,10 @@ final case class BankDetails(
     accountName       = "***",
     maybeDDIRefNumber = maybeDDIRefNumber.map(_ => "***")
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object BankDetails {

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/BankDetailsRequest.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/BankDetailsRequest.scala
@@ -25,6 +25,10 @@ final case class BankDetailsRequest(sortCode:      String,
     sortCode      = "***",
     accountNumber = "***"
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object BankDetailsRequest {

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstruction.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstruction.scala
@@ -43,6 +43,10 @@ final case class DirectDebitInstruction(
     ddiRefNumber    = ddiRefNumber.map(_ => "***"),
     ddiReferenceNo  = ddiReferenceNo.map(_ => "***")
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object DirectDebitInstruction {

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstructionPaymentPlan.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstructionPaymentPlan.scala
@@ -22,7 +22,16 @@ import play.api.libs.json.{Format, Json}
 final case class DirectDebitInstructionPaymentPlan(processingDate:         String,
                                                    acknowledgementId:      String,
                                                    directDebitInstruction: List[DirectDebitInstruction],
-                                                   paymentPlan:            List[DirectDebitPaymentPlan])
+                                                   paymentPlan:            List[DirectDebitPaymentPlan]) {
+
+  def obfuscate: DirectDebitInstructionPaymentPlan = copy(
+    directDebitInstruction = directDebitInstruction.map(_.obfuscate)
+  )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
+}
 
 object DirectDebitInstructionPaymentPlan {
   implicit val format: Format[DirectDebitInstructionPaymentPlan] = Json.format[DirectDebitInstructionPaymentPlan]

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstructions.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/DirectDebitInstructions.scala
@@ -22,6 +22,10 @@ final case class DirectDebitInstructions(directDebitInstruction: Seq[DirectDebit
   def obfuscate: DirectDebitInstructions = DirectDebitInstructions(
     directDebitInstruction = directDebitInstruction.map(_.obfuscate)
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object DirectDebitInstructions {

--- a/app/uk/gov/hmrc/selfservicetimetopay/models/TTPArrangement.scala
+++ b/app/uk/gov/hmrc/selfservicetimetopay/models/TTPArrangement.scala
@@ -31,6 +31,10 @@ final case class TTPArrangement(paymentPlanReference: String,
     taxpayer             = taxpayer.obfuscate,
     schedule             = schedule
   )
+
+  override def toString: String = {
+    obfuscate.productIterator.mkString(productPrefix + "(", ",", ")")
+  }
 }
 
 object TTPArrangement {


### PR DESCRIPTION
This change modifies Journey#toString and DirectDebitInstructionPaymentPlan#toString behaviour such that it is not possible to accidentally render these instances with PII exposed