### PR TITLE
[MP][OPS-5452] 2019/20 data displaying as 2020/21 data

### DIFF
--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -58,8 +58,6 @@ package object model {
   }
 
   implicit class DebitExt(val v: Debit) extends AnyVal {
-    def dueByYear(offset: Int = 0): Int = v.dueDate.getYear - offset
-
-    // def taxYearStart: Int = v.taxYearEnd.getYear - 1
+    def taxYearStart: Int = v.taxYearEnd.getYear - 1
   }
 }

--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -58,6 +58,7 @@ package object model {
   }
 
   implicit class DebitExt(val v: Debit) extends AnyVal {
-    def taxYearStart: Int = v.taxYearEnd.getYear - 1
+    def startTaxYear: Int = v.taxYearEnd.getYear - 1
+    def endTaxYear: Int = v.taxYearEnd.getYear
   }
 }

--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -59,5 +59,7 @@ package object model {
 
   implicit class DebitExt(val v: Debit) extends AnyVal {
     def dueByYear(offset: Int = 0): Int = v.dueDate.getYear - offset
+
+    // def taxYearStart: Int = v.taxYearEnd.getYear - 1
   }
 }

--- a/app/views/partials/tax_liabilities_summary.scala.html
+++ b/app/views/partials/tax_liabilities_summary.scala.html
@@ -25,7 +25,7 @@
         <div class="tabular-data__entry border-bottom">
           <span class="tabular-data__heading tabular-data__heading--label">
             <h2 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.dueDate)}</h2>
-            <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.startTaxYear, debit.endTaxYear) </p>
+            <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.startTaxYear.toString, debit.endTaxYear.toString) </p>
           </span>
           <div class="tabular-data__data-1"><span class="normal-text">@partials.currency(debit.amount)</span></div>
         </div>

--- a/app/views/partials/tax_liabilities_summary.scala.html
+++ b/app/views/partials/tax_liabilities_summary.scala.html
@@ -26,6 +26,7 @@
           <span class="tabular-data__heading tabular-data__heading--label">
             <h2 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.dueDate)}</h2>
             <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.dueByYear(1).toString, debit.dueByYear().toString) </p>
+@*              <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.taxYearStart.toString, debit.taxYearEnd.getYear.toString) </p>              *@
           </span>
           <div class="tabular-data__data-1"><span class="normal-text">@partials.currency(debit.amount)</span></div>
         </div>

--- a/app/views/partials/tax_liabilities_summary.scala.html
+++ b/app/views/partials/tax_liabilities_summary.scala.html
@@ -25,7 +25,7 @@
         <div class="tabular-data__entry border-bottom">
           <span class="tabular-data__heading tabular-data__heading--label">
             <h2 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.dueDate)}</h2>
-              <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.taxYearStart.toString, debit.taxYearEnd.getYear.toString) </p>
+            <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.startTaxYear, debit.endTaxYear) </p>
           </span>
           <div class="tabular-data__data-1"><span class="normal-text">@partials.currency(debit.amount)</span></div>
         </div>

--- a/app/views/partials/tax_liabilities_summary.scala.html
+++ b/app/views/partials/tax_liabilities_summary.scala.html
@@ -25,8 +25,7 @@
         <div class="tabular-data__entry border-bottom">
           <span class="tabular-data__heading tabular-data__heading--label">
             <h2 class="heading-small">@(Messages("ssttp.calculator.self-assessment-account-summary-page.due")) @{language.Dates.formatDate(debit.dueDate)}</h2>
-            <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.dueByYear(1).toString, debit.dueByYear().toString) </p>
-@*              <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.taxYearStart.toString, debit.taxYearEnd.getYear.toString) </p>              *@
+              <p>@partials.charge_code(debit.originCode, debit.taxYearEnd) @Messages("ssttp.calculator.self-assessment-account-summary-page.for-tax-year", debit.taxYearStart.toString, debit.taxYearEnd.getYear.toString) </p>
           </span>
           <div class="tabular-data__data-1"><span class="normal-text">@partials.currency(debit.amount)</span></div>
         </div>

--- a/test/pagespecs/CalculatorTaxLiabilitiesPageSpec.scala
+++ b/test/pagespecs/CalculatorTaxLiabilitiesPageSpec.scala
@@ -20,8 +20,33 @@ import langswitch.Languages.{English, Welsh}
 import testsupport.ItSpec
 import testsupport.stubs.DirectDebitStub.getBanksIsSuccessful
 import testsupport.stubs.{AuthStub, GgStub, IaStub, TaxpayerStub}
+import testsupport.testdata.TdAll
+import testsupport.testdata.TdAll.toLocalDate
+
+import testsupport.testdata.TdAll.{address, communicationPreferences, debit1, debit1Amount, debit2, debit2Amount, dueDate, saUtr, taxYearEnd}
+import timetopaytaxpayer.cor.model.{Debit, Return, SelfAssessmentDetails, Taxpayer}
+
+import java.time.LocalDate
 
 class CalculatorTaxLiabilitiesPageSpec extends ItSpec {
+
+  private val debit1Amount = 2500
+  private val debit2Amount = 3000
+
+  val lateDebit1: Debit = Debit(originCode = "IN1", debit1Amount, dueDate = "2021-06-01", interest = None, taxYearEnd)
+  val lateDebit2: Debit = Debit(originCode = "IN2", amount = debit2Amount, dueDate, interest = None, taxYearEnd)
+
+  val taxpayerWithLateDebit: Taxpayer =
+    Taxpayer(
+      "Mr John Campbell",
+      List(address),
+      SelfAssessmentDetails(
+        saUtr,
+        communicationPreferences,
+        List(debit1, debit2),
+        List(
+          Return(taxYearEnd, issuedDate = "2019-11-10", dueDate = "2019-08-15", receivedDate = "2019-03-09"),
+          Return(taxYearEnd   = "2018-04-05", issuedDate = "2017-02-15", dueDate = "2018-01-31", receivedDate = "2018-03-09"))))
 
   def beginJourney(): Unit = {
     AuthStub.authorise()

--- a/test/pagespecs/pages/CalculatorTaxLiabilitiesPage.scala
+++ b/test/pagespecs/pages/CalculatorTaxLiabilitiesPage.scala
@@ -71,11 +71,11 @@ class CalculatorTaxLiabilitiesPage(baseUrl: BaseUrl)(implicit webDriver: WebDriv
         """Your Self Assessment tax bill is £4,900.00
           |Self Assessment statement
           |Due 25 November 2019
-          |First payment on account for tax year 2018 to 2019
+          |First payment on account for tax year 2019 to 2020
           |
           |£2,500.00
           |Due 25 November 2019
-          |Second payment on account for tax year 2018 to 2019
+          |Second payment on account for tax year 2019 to 2020
           |
           |£2,400.00
           |Continue
@@ -85,11 +85,11 @@ class CalculatorTaxLiabilitiesPage(baseUrl: BaseUrl)(implicit webDriver: WebDriv
         """Crynodeb o’ch cyfrif Hunanasesiad £4,900.00
           |Dadansoddiad Hunanasesiad
           |Due 25 November 2019
-          |Taliad cyntaf ar gyfrif for tax year 2018 to 2019
+          |Taliad cyntaf ar gyfrif for tax year 2019 to 2020
           |
           |£2,500.00
           |Due 25 November 2019
-          |Ail daliad ar gyfrif for tax year 2018 to 2019
+          |Ail daliad ar gyfrif for tax year 2019 to 2020
           |
           |£2,400.00
           |Yn eich blaen

--- a/test/testsupport/stubs/TaxpayerStub.scala
+++ b/test/testsupport/stubs/TaxpayerStub.scala
@@ -24,13 +24,17 @@ import play.api.http.Status
 import play.api.libs.json.Json.{prettyPrint, toJson}
 import testsupport.testdata.EligibilityTaxpayerVariationsTd._
 import testsupport.testdata.TdAll.{taxpayer, utr}
+import timetopaytaxpayer.cor.model.Taxpayer
 import uk.gov.hmrc.selfservicetimetopay.models._
 
 object TaxpayerStub extends Matchers with Status {
   private val url: UrlPathPattern = urlPathEqualTo(s"/taxpayer/$utr")
 
+  def getTaxpayer(tp: Taxpayer): StubMapping =
+    stubFor(get(url).willReturn(aResponse().withStatus(OK).withBody(prettyPrint(toJson(tp)))))
+
   def getTaxpayer(): StubMapping =
-    stubFor(get(url).willReturn(aResponse().withStatus(OK).withBody(prettyPrint(toJson(taxpayer)))))
+    getTaxpayer(taxpayer)
 
   def getTaxpayer(reason: Reason): StubMapping =
     stubFor(get(url).willReturn(aResponse()


### PR DESCRIPTION
The issue being corrected is using years derived from `dueDate` to calculate and display the tax-years. This usually isn't a problem because `dueDate` and `taxYearEnd` tend to be from the same tax year so there's no discrepancy.