### PR TITLE
[AM][OPS-10064][OPS-10065]

### DIFF
--- a/app/ssttpcalculator/CalculatorForm.scala
+++ b/app/ssttpcalculator/CalculatorForm.scala
@@ -23,7 +23,7 @@ import play.api.data.{Form, FormError, Forms, Mapping}
 import uk.gov.hmrc.selfservicetimetopay.models._
 import uk.gov.voa.play.form.ConditionalMappings.{isEqual, mandatoryIf}
 
-import scala.math.BigDecimal.RoundingMode.{CEILING, HALF_UP}
+import scala.math.BigDecimal.RoundingMode.{CEILING, FLOOR, HALF_UP}
 import scala.util.Try
 
 object CalculatorForm {
@@ -129,7 +129,7 @@ object CalculatorForm {
         if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) >= 0 else true
       })
       .verifying(Constraint((i: String) => if ({
-        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) < 0 || BigDecimal(i) >= minCustomAmount else true
+        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) < 0 || BigDecimal(i) >= minCustomAmount.setScale(2, FLOOR) else true
       }) Valid else {
         Invalid(Seq(ValidationError(
           "ssttp.calculator.results.option.other.error.below-minimum",

--- a/app/ssttpcalculator/CalculatorForm.scala
+++ b/app/ssttpcalculator/CalculatorForm.scala
@@ -90,7 +90,7 @@ object CalculatorForm {
   }
 
   private def customSelectionWithSafeMax(radioSelection: String, maxCustomAmount: BigDecimal): BigDecimal = {
-    if (BigDecimal(radioSelection) == maxCustomAmount.setScale(2, HALF_UP)) {
+    if (BigDecimal(radioSelection).setScale(2, HALF_UP) == maxCustomAmount.setScale(2, HALF_UP)) {
       maxCustomAmount
     } else BigDecimal(radioSelection)
   }
@@ -100,7 +100,6 @@ object CalculatorForm {
       case Left(SelectedPlan(instalmentAmount))   => (instalmentAmount.toString, None)
       case Right(CustomPlanRequest(customAmount)) => ("customAmountOption", Some(customAmount.toString()))
     }
-
   }
 
   def selectPlanForm(minCustomAmount: BigDecimal, maxCustomAmount: BigDecimal): Form[PlanSelection] =
@@ -129,7 +128,7 @@ object CalculatorForm {
         if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) >= 0 else true
       })
       .verifying(Constraint((i: String) => if ({
-        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) < 0 || BigDecimal(i) >= minCustomAmount.setScale(2, FLOOR) else true
+        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) < 0 || BigDecimal(i) >= minCustomAmount.setScale(2, HALF_UP) else true
       }) Valid else {
         Invalid(Seq(ValidationError(
           "ssttp.calculator.results.option.other.error.below-minimum",
@@ -138,7 +137,7 @@ object CalculatorForm {
         )))
       }))
       .verifying(Constraint((i: String) => if ({
-        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) <= maxCustomAmount.setScale(2, CEILING) else true
+        if (Try(BigDecimal(i)).isSuccess) BigDecimal(i) <= maxCustomAmount.setScale(2, HALF_UP) else true
       }) Valid else {
         Invalid(Seq(ValidationError(
           "ssttp.calculator.results.option.other.error.above-maximum",

--- a/test/ssttpcalculator/CalculatorFormSpec.scala
+++ b/test/ssttpcalculator/CalculatorFormSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssttpcalculator
+
+import testsupport.UnitSpec
+import uk.gov.hmrc.selfservicetimetopay.models.CustomPlanRequest
+
+class CalculatorFormSpec extends UnitSpec {
+
+  "CalculatorForm.apply generates a plan selection data structure" - {
+    "if the radio selection is the custom amount option" +
+      " then it generates the plan selection with a custom plan request" - {
+      }
+    "Using the max custom amount not rounded if selected:" +
+      " if the custom amount input is equal to the max custom amount (rounded to two decimal places" +
+      " then the custom amount in the request is the max custom amount not rounded" - {
+        "where maxCustomAmount rounds DOWN to 2 dc to WHOLE NUMBER (£XX)" in {
+
+          val maxCustomAmount = 1000.004
+
+          val radioSelection = "customAmountOption"
+          val customAmountInput = Some("1000")
+
+          val result = CalculatorForm.apply(maxCustomAmount)(radioSelection, customAmountInput)
+
+          result.selection shouldBe Right(CustomPlanRequest(maxCustomAmount))
+        }
+        "where maxCustomAmount rounds down to 2 dp with NUMBER WITH 2 DP (£XX.XX)" in {
+
+          val maxCustomAmount = 1000.504
+
+          val radioSelection = "customAmountOption"
+          val customAmountInput = Some("1000.50")
+
+          val result = CalculatorForm.apply(maxCustomAmount)(radioSelection, customAmountInput)
+
+          result.selection shouldBe Right(CustomPlanRequest(maxCustomAmount))
+        }
+        "where maxCustomAmount rounds UP to 2 dc to WHOLE NUMBER (£XX)" in {
+
+          val maxCustomAmount = 1000.995
+
+          val radioSelection = "customAmountOption"
+          val customAmountInput = Some("1001")
+
+          val result = CalculatorForm.apply(maxCustomAmount)(radioSelection, customAmountInput)
+
+          result.selection shouldBe Right(CustomPlanRequest(maxCustomAmount))
+        }
+        "where maxCustomAmount rounds UP to 2 dc to NUMBER WITH 2 DP (£XX.XX)" in {
+
+          val maxCustomAmount = 1000.005
+
+          val radioSelection = "customAmountOption"
+          val customAmountInput = Some("1000.01")
+
+          val result = CalculatorForm.apply(maxCustomAmount)(radioSelection, customAmountInput)
+
+          result.selection shouldBe Right(CustomPlanRequest(maxCustomAmount))
+        }
+
+      }
+    "Otherwise: " +
+      " if the custom amount input is NOT equal to the max custom amount (rounded)" +
+      " then the custom amount in the request is the custom amount input" in {
+
+        val maxCustomAmount = 1000.004
+
+        val radioSelection = "customAmountOption"
+        val customAmountInput = Some("1001")
+
+        val result = CalculatorForm.apply(maxCustomAmount)(radioSelection, customAmountInput)
+
+        result.selection shouldBe Right(CustomPlanRequest(BigDecimal(customAmountInput.get)))
+
+      }
+  }
+  "if the radio selection is one of the plans" +
+    " then it generates the plan selection with a selected plan" - {
+      "Using the max custom amount not rounded if selected:" +
+        " if the radio selection amount (rounded to 2 DP - just in case) is equal to the max custom amount (rounded to 2 DP)" +
+        " then the selected plan amount is the max custom amount not rounded" in {
+
+        }
+      "Otherwise: " +
+        " if the radio selection amount (rounded) is NOT equal to the max custom amount (rounded)" +
+        " then the radio selection value is used in the plan selection" in {
+
+        }
+    }
+}


### PR DESCRIPTION
- Remove upfront payment limit to bring in line with current in-production service: https://jira.tools.tax.service.gov.uk/browse/OPS-10065
- Fix to make max and min validations tighter on 'Update maximum allowable custom amount so that it generates a 1 month custom plan: https://jira.tools.tax.service.gov.uk/browse/OPS-10064