### PR TITLE
[AM][OPS-10202] Add calculator type feature switch and remove custom amount input option from Legacy calculator type

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,6 +17,7 @@
 package config
 
 import play.api.libs.json.{Json, OFormat}
+import ssttpcalculator.CalculatorType
 import ssttpcalculator.model.TaxLiability
 
 import javax.inject.Inject
@@ -68,4 +69,10 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig) {
   lazy val firstPaymentDayOfMonth: Int = servicesConfig.getInt("paymentDatesConfig.firstPaymentDayOfMonth")
   lazy val lastPaymentDayOfMonth: Int = servicesConfig.getInt("paymentDatesConfig.lastPaymentDayOfMonth")
   lazy val lastPaymentDelayDays: Int = servicesConfig.getInt("paymentDatesConfig.lastPaymentDelayDays")
+
+  lazy val calculatorType: CalculatorType = servicesConfig.getString("calculatorType") match {
+    case CalculatorType.Legacy.value           => CalculatorType.Legacy
+    case CalculatorType.PaymentOptimised.value => CalculatorType.PaymentOptimised
+    case otherValue                            => throw new Exception(s"calculator type '$otherValue' in config not recognised")
+  }
 }

--- a/app/ssttpcalculator/CalculatorController.scala
+++ b/app/ssttpcalculator/CalculatorController.scala
@@ -16,7 +16,6 @@
 
 package ssttpcalculator
 
-import audit.AuditService
 import config.AppConfig
 import controllers.FrontendBaseController
 import controllers.action.Actions
@@ -33,7 +32,7 @@ import uk.gov.hmrc.selfservicetimetopay.models._
 import views.Views
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.math.BigDecimal.RoundingMode.{CEILING, HALF_UP}
+import scala.math.BigDecimal.RoundingMode.HALF_UP
 
 class CalculatorController @Inject() (
     mcc:                 MessagesControllerComponents,
@@ -158,36 +157,37 @@ class CalculatorController @Inject() (
         journey.remainingIncomeAfterSpending
       )
 
-      if (defaultPlanOptions.isEmpty) {
-        Redirect(ssttpaffordability.routes.AffordabilityController.getWeCannotAgreeYourPP())
-      } else {
-        appConfig.calculatorType match {
+      defaultPlanOptions.values.toSeq.sortBy(_.instalmentAmount).headOption match {
+        case None =>
+          Redirect(ssttpaffordability.routes.AffordabilityController.getWeCannotAgreeYourPP())
 
-          case CalculatorType.Legacy =>
-            Ok(views.how_much_can_you_pay_each_month_form_legacy(
-              routes.CalculatorController.submitCalculateInstalments(),
-              selectPlanForm(),
-              defaultPlanOptions,
-              journey.maybePlanSelection))
+        case Some(scheduleWithSmallestInstalmentAmount) =>
+          appConfig.calculatorType match {
 
-          case CalculatorType.PaymentOptimised =>
-            val minCustomAmount = defaultPlanOptions.values
-              .headOption.fold(BigDecimal(1))(_.firstInstalment.amount)
-            val maxCustomAmount = paymentPlansService.maximumPossibleInstalmentAmount(journey)
+            case CalculatorType.Legacy =>
+              Ok(views.how_much_can_you_pay_each_month_form_legacy(
+                routes.CalculatorController.submitCalculateInstalments(),
+                selectPlanForm(),
+                defaultPlanOptions,
+                journey.maybePlanSelection))
 
-            val allPlanOptions = maybePreviousCustomAmount(journey, defaultPlanOptions) match {
-              case None                 => defaultPlanOptions
-              case Some(customSchedule) => Map((0, customSchedule)) ++ defaultPlanOptions
-            }
+            case CalculatorType.PaymentOptimised =>
+              val minCustomAmount = scheduleWithSmallestInstalmentAmount.instalmentAmount
+              val maxCustomAmount = paymentPlansService.maximumPossibleInstalmentAmount(journey)
 
-            Ok(views.how_much_can_you_pay_each_month_form(
-              routes.CalculatorController.submitCalculateInstalments(),
-              selectPlanForm(minCustomAmount, maxCustomAmount),
-              allPlanOptions,
-              minCustomAmount.setScale(2, HALF_UP),
-              maxCustomAmount.setScale(2, HALF_UP),
-              journey.maybePlanSelection))
-        }
+              val allPlanOptions = maybePreviousCustomAmount(journey, defaultPlanOptions) match {
+                case None                 => defaultPlanOptions
+                case Some(customSchedule) => Map((0, customSchedule)) ++ defaultPlanOptions
+              }
+
+              Ok(views.how_much_can_you_pay_each_month_form(
+                routes.CalculatorController.submitCalculateInstalments(),
+                selectPlanForm(minCustomAmount, maxCustomAmount),
+                allPlanOptions,
+                minCustomAmount.setScale(2, HALF_UP),
+                maxCustomAmount.setScale(2, HALF_UP),
+                journey.maybePlanSelection))
+          }
       }
 
     }
@@ -204,8 +204,9 @@ class CalculatorController @Inject() (
         journey.maybePaymentDayOfMonth,
         journey.remainingIncomeAfterSpending
       )
-      val minCustomAmount = paymentPlanOptions.values
-        .headOption.fold(BigDecimal(1))(_.firstInstalment.amount)
+      val minCustomAmount = paymentPlanOptions.values.toSeq
+        .sortBy(_.instalmentAmount)
+        .headOption.fold(BigDecimal(1))(_.instalmentAmount)
       val maxCustomAmount = paymentPlansService.maximumPossibleInstalmentAmount(journey)
 
       selectPlanForm(minCustomAmount, maxCustomAmount).bindFromRequest().fold(

--- a/app/ssttpcalculator/CalculatorController.scala
+++ b/app/ssttpcalculator/CalculatorController.scala
@@ -158,33 +158,28 @@ class CalculatorController @Inject() (
         journey.remainingIncomeAfterSpending
       )
 
-      appConfig.calculatorType match {
-        case CalculatorType.Legacy =>
-          if (defaultPlanOptions.isEmpty) {
-            Redirect(ssttpaffordability.routes.AffordabilityController.getWeCannotAgreeYourPP())
-          } else {
+      if (defaultPlanOptions.isEmpty) {
+        Redirect(ssttpaffordability.routes.AffordabilityController.getWeCannotAgreeYourPP())
+      } else {
+        appConfig.calculatorType match {
+
+          case CalculatorType.Legacy =>
             Ok(views.how_much_can_you_pay_each_month_form_legacy(
               routes.CalculatorController.submitCalculateInstalments(),
-              selectPlanForm(BigDecimal(0), BigDecimal(1000000000)),
+              selectPlanForm(),
               defaultPlanOptions,
-              BigDecimal(0),
-              BigDecimal(1000000000),
               journey.maybePlanSelection))
-          }
 
-        case CalculatorType.PaymentOptimised =>
-          val minCustomAmount = defaultPlanOptions.values
-            .headOption.fold(BigDecimal(1))(_.firstInstalment.amount)
-          val maxCustomAmount = paymentPlansService.maximumPossibleInstalmentAmount(journey)
+          case CalculatorType.PaymentOptimised =>
+            val minCustomAmount = defaultPlanOptions.values
+              .headOption.fold(BigDecimal(1))(_.firstInstalment.amount)
+            val maxCustomAmount = paymentPlansService.maximumPossibleInstalmentAmount(journey)
 
-          val allPlanOptions = maybePreviousCustomAmount(journey, defaultPlanOptions) match {
-            case None                 => defaultPlanOptions
-            case Some(customSchedule) => Map((0, customSchedule)) ++ defaultPlanOptions
-          }
+            val allPlanOptions = maybePreviousCustomAmount(journey, defaultPlanOptions) match {
+              case None                 => defaultPlanOptions
+              case Some(customSchedule) => Map((0, customSchedule)) ++ defaultPlanOptions
+            }
 
-          if (defaultPlanOptions.isEmpty) {
-            Redirect(ssttpaffordability.routes.AffordabilityController.getWeCannotAgreeYourPP())
-          } else {
             Ok(views.how_much_can_you_pay_each_month_form(
               routes.CalculatorController.submitCalculateInstalments(),
               selectPlanForm(minCustomAmount, maxCustomAmount),
@@ -192,7 +187,7 @@ class CalculatorController @Inject() (
               minCustomAmount.setScale(2, HALF_UP),
               maxCustomAmount.setScale(2, HALF_UP),
               journey.maybePlanSelection))
-          }
+        }
       }
 
     }

--- a/app/ssttpcalculator/CalculatorForm.scala
+++ b/app/ssttpcalculator/CalculatorForm.scala
@@ -102,7 +102,7 @@ object CalculatorForm {
     }
   }
 
-  def selectPlanForm(minCustomAmount: BigDecimal, maxCustomAmount: BigDecimal): Form[PlanSelection] =
+  def selectPlanForm(minCustomAmount: BigDecimal = 0, maxCustomAmount: BigDecimal = 0): Form[PlanSelection] =
     Form(mapping(
       "plan-selection" -> planSelectionMapping,
       "custom-amount-input" -> mandatoryIf(

--- a/app/ssttpcalculator/CalculatorType.scala
+++ b/app/ssttpcalculator/CalculatorType.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssttpcalculator
+
+sealed trait CalculatorType {
+  val value: String
+}
+
+object CalculatorType {
+  case object Legacy extends CalculatorType {
+    val value: String = "Legacy"
+  }
+
+  case object PaymentOptimised extends CalculatorType {
+    val value: String = "PaymentOptimised"
+  }
+}
+

--- a/app/ssttpcalculator/model/PaymentSchedule.scala
+++ b/app/ssttpcalculator/model/PaymentSchedule.scala
@@ -32,6 +32,8 @@ final case class PaymentSchedule(
   def firstInstalment: Instalment =
     instalments.reduceOption(first).getOrElse(throw new RuntimeException(s"No instalments for [$this]"))
 
+  def instalmentAmount: BigDecimal = firstInstalment.amount
+
   private def first(earliest: Instalment, next: Instalment): Instalment =
     if (next.paymentDate.toEpochDay < earliest.paymentDate.toEpochDay) next else earliest
 

--- a/app/views/Views.scala
+++ b/app/views/Views.scala
@@ -29,6 +29,7 @@ class Views @Inject() (
     val how_much_you_could_afford:                     views.html.affordability.how_much_you_could_afford,
     val we_cannot_agree_your_pp:                       views.html.affordability.we_cannot_agree_your_pp,
     val how_much_can_you_pay_each_month_form:          views.html.calculator.how_much_can_you_pay_each_month_form,
+    val how_much_can_you_pay_each_month_form_legacy:   views.html.calculator.legacy.how_much_can_you_pay_each_month_form_legacy,
     val payment_summary:                               views.html.calculator.payment_summary,
     val tax_liabilities:                               views.html.calculator.tax_liabilities,
     val about_bank_account:                            views.html.arrangement.about_bank_account,

--- a/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
+++ b/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
@@ -1,0 +1,167 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import partials.currency
+@import uk.gov.hmrc.selfservicetimetopay.models.{PlanSelection, SelectedPlan, CustomPlanRequest}
+@import ssttpcalculator.model._
+@import model._
+@import helpers.forms.submit
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Radios
+@import uk.gov.hmrc.govukfrontend.views.Aliases.RadioItem
+@import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
+@import uk.gov.hmrc.govukfrontend.views.Aliases.ErrorSummary
+@import uk.gov.hmrc.govukfrontend.views.Implicits._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage.errorMessageWithDefaultStringsTranslated
+
+@this(
+  main: views.html.main,
+  errorSummary: uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary,
+  radios: uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios,
+  viewsHelpers: views.ViewsHelpers
+)
+
+@(
+        redirectCall: Call,
+        selectPlanForm: Form[PlanSelection],
+        schedules: Map[Int, PaymentSchedule],
+        minCustomAmount: BigDecimal,
+        maxCustomAmount: BigDecimal,
+        previousFormSubmission: Option[PlanSelection])(
+        implicit
+        messages: play.api.i18n.Messages,
+        request: Request[_],
+        appConfig: config.AppConfig
+)
+
+@scheduleOptionsSequence = @{schedules.toSeq.map ( schedule => {
+    RadioItem(
+        id = Some(schedule._1.toString),
+        value = Some(schedule._2.getMonthlyInstalment.toString),
+        content = HtmlContent(Messages(
+            "ssttp.calculator.results.amount.option",
+            currency(schedule._2.firstInstallment.amount),
+            if (schedule._2.durationInMonths < 0) 12 + schedule._2.durationInMonths else schedule._2.durationInMonths
+        )),
+        hint = Some(Hint(content = HtmlContent(Messages(
+            "ssttp.calculator.results.amount.option.interest-hint",
+            currency(schedule._2.totalInterestCharged)
+        )))),
+        checked = previousFormSubmission.fold(false)(_.selection match {
+            case Left(SelectedPlan(amount)) => amount == schedule._2.getMonthlyInstalment
+            case Right(CustomPlanRequest(_)) => false
+        })
+    )
+})}
+
+@customAmountHasErrors = @{selectPlanForm("plan-selection").value.contains("customAmountOption")}
+
+@customAmountSelected() = @{
+    if(customAmountHasErrors){
+        "checked"
+    }
+}
+
+@errorFocus(key: String) = @{
+    if(customAmountHasErrors){
+        "custom-amount-option"
+    }else{
+        key
+    }
+}
+
+@enterCustomAmountPanel = {
+<div id="custom-amount-field" class="govuk-form-group @if(customAmountHasErrors){govuk-form-group--error}">
+    <div class="govuk-hint">@Html(messages("ssttp.calculator.results.option.other.enter.amount", currency(minCustomAmount), currency(maxCustomAmount)))</div>
+    @if(customAmountHasErrors) {
+        <span id="custom-amount-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">@messages("ssttp.common.title-prefix")</span>
+            @selectPlanForm.error("custom-amount-input").map(formError => Html(messages(formError.message, minCustomAmount, maxCustomAmount)))
+        </span>
+    }
+    <div class="govuk-input__wrapper">
+        <div class="govuk-input__prefix" aria-hidden="true">£</div>
+        <input class="govuk-input govuk-input--width-5 @if(customAmountHasErrors){govuk-input--error}" id="custom-amount-input" name="custom-amount-input" type="text" spellcheck="false" value="@{selectPlanForm.data.get("custom-amount-input")}">
+    </div>
+</div>
+}
+
+@main(
+    title = Messages("ssttp.calculator.results.title"),
+    hasErrors = selectPlanForm.hasErrors
+) {
+
+<section class="govuk-body">
+
+@if(selectPlanForm.hasErrors) {
+    @errorSummary(
+        ErrorSummary(
+            title = Text(Messages("ssttp.calculator.results.error.title")),
+            errorList = selectPlanForm.errors.asTextErrorLinks.map {error =>
+                if(error.content == Text(messages("ssttp.calculator.results.option.error.no-selection"))) error.copy (
+                    href = schedules.headOption.fold(error.href)(s => error.href.map(_.replaceAll("plan-selection", s._1.toString)))
+                ) else error
+            }
+        )
+    )
+}
+
+
+
+@viewsHelpers.form(redirectCall, 'id -> "paymentTodayForm") {
+    <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-heading-xl">@Messages("ssttp.calculator.results.title")</h1>
+        </legend>
+
+        <p class="govuk-body">
+            @{previousFormSubmission.fold(messages("ssttp.calculator.results.p1"))(_.selection match {
+                case Right(CustomPlanRequest(amount)) => messages("ssttp.calculator.results.p1.custom-amount", currency(amount))
+                case Left(SelectedPlan(amount)) if schedules.headOption.fold(false)(_._1 == 0) => messages("ssttp.calculator.results.p1.custom-amount", currency(amount))
+                case _ => messages("ssttp.calculator.results.p1")
+            })}
+        </p>
+        <p class="govuk-body">@messages("ssttp.calculator.results.p2")</p>
+
+        @radios(Radios(
+            name = "plan-selection",
+            attributes = Map("id" -> "selected-plan-amount"),
+            errorMessage = selectPlanForm.error("plan-selection").map(error => errorMessageWithDefaultStringsTranslated(content = Text(messages("ssttp.calculator.results.option.error.no-selection")))),
+            items =  Seq(scheduleOptionsSequence.headOption.getOrElse(throw new IllegalArgumentException("Could not find any valid schedule options")),
+            RadioItem(
+                divider = Some(Messages("ssttp.calculator.results.or"))
+            ))   ++ scheduleOptionsSequence.drop(1)
+        ))
+    </fieldset>
+
+<details class="govuk-details">
+  <summary class="govuk-details__summary"><span class="govuk-details__summary-text">@Messages("ssttp.calculator.results.section.cannot-afford.title")</span></summary>
+  <div class="govuk-details__text">
+    <p>@Messages("ssttp.calculator.results.section.cannot-afford.p.1") <strong class="bold">@Messages("ssttp.calculator.results.section.cannot-afford.p.2")</strong> @Messages("ssttp.calculator.results.section.cannot-afford.p.3")</p>
+  </div>
+</details>
+
+<div class="clear">
+ <div class="form-group">
+  <button id="next" type="submit" class="govuk-button" onclick="continue()">@Messages("ssttp.calculator.form.continue")</button>
+ </div>
+</div>
+}
+
+</section>
+}

--- a/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
+++ b/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import partials.currency
-@import uk.gov.hmrc.selfservicetimetopay.models.{PlanSelection, SelectedPlan, CustomPlanRequest}
+@import uk.gov.hmrc.selfservicetimetopay.models.{PlanSelection, SelectedPlan}
 @import ssttpcalculator.model._
 @import model._
 @import helpers.forms.submit
@@ -40,8 +40,6 @@
         redirectCall: Call,
         selectPlanForm: Form[PlanSelection],
         schedules: Map[Int, PaymentSchedule],
-        minCustomAmount: BigDecimal,
-        maxCustomAmount: BigDecimal,
         previousFormSubmission: Option[PlanSelection])(
         implicit
         messages: play.api.i18n.Messages,
@@ -64,42 +62,11 @@
         )))),
         checked = previousFormSubmission.fold(false)(_.selection match {
             case Left(SelectedPlan(amount)) => amount == schedule._2.getMonthlyInstalment
-            case Right(CustomPlanRequest(_)) => false
+            case _ => false
         })
     )
 })}
 
-@customAmountHasErrors = @{selectPlanForm("plan-selection").value.contains("customAmountOption")}
-
-@customAmountSelected() = @{
-    if(customAmountHasErrors){
-        "checked"
-    }
-}
-
-@errorFocus(key: String) = @{
-    if(customAmountHasErrors){
-        "custom-amount-option"
-    }else{
-        key
-    }
-}
-
-@enterCustomAmountPanel = {
-<div id="custom-amount-field" class="govuk-form-group @if(customAmountHasErrors){govuk-form-group--error}">
-    <div class="govuk-hint">@Html(messages("ssttp.calculator.results.option.other.enter.amount", currency(minCustomAmount), currency(maxCustomAmount)))</div>
-    @if(customAmountHasErrors) {
-        <span id="custom-amount-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">@messages("ssttp.common.title-prefix")</span>
-            @selectPlanForm.error("custom-amount-input").map(formError => Html(messages(formError.message, minCustomAmount, maxCustomAmount)))
-        </span>
-    }
-    <div class="govuk-input__wrapper">
-        <div class="govuk-input__prefix" aria-hidden="true">£</div>
-        <input class="govuk-input govuk-input--width-5 @if(customAmountHasErrors){govuk-input--error}" id="custom-amount-input" name="custom-amount-input" type="text" spellcheck="false" value="@{selectPlanForm.data.get("custom-amount-input")}">
-    </div>
-</div>
-}
 
 @main(
     title = Messages("ssttp.calculator.results.title"),
@@ -129,13 +96,7 @@
             <h1 class="govuk-heading-xl">@Messages("ssttp.calculator.results.title")</h1>
         </legend>
 
-        <p class="govuk-body">
-            @{previousFormSubmission.fold(messages("ssttp.calculator.results.p1"))(_.selection match {
-                case Right(CustomPlanRequest(amount)) => messages("ssttp.calculator.results.p1.custom-amount", currency(amount))
-                case Left(SelectedPlan(amount)) if schedules.headOption.fold(false)(_._1 == 0) => messages("ssttp.calculator.results.p1.custom-amount", currency(amount))
-                case _ => messages("ssttp.calculator.results.p1")
-            })}
-        </p>
+        <p class="govuk-body">@messages("ssttp.calculator.results.p1")</p>
         <p class="govuk-body">@messages("ssttp.calculator.results.p2")</p>
 
         @radios(Radios(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,9 @@ play.i18n.langs = ["en", "cy"]
 # Custom error handler
 play.http.errorHandler = "controllers.ErrorHandler"
 
+# Config for calculator
+calculatorType = Legacy
+
 # Config for payment dates
 paymentDatesConfig {
   minimumLengthOfPaymentPlan = 1

--- a/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
+++ b/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
@@ -17,12 +17,17 @@
 package pagespecs.legacycalculator
 
 import langswitch.Languages.{English, Welsh}
+import ssttpcalculator.CalculatorType.Legacy
 import testsupport.ItSpec
 import testsupport.stubs.DirectDebitStub.getBanksIsSuccessful
 import testsupport.stubs._
 import testsupport.testdata.TdAll.{defaultRemainingIncomeAfterSpending, netIncomeLargeEnoughForSingleDefaultPlan, netIncomeLargeEnoughForTwoDefaultPlans, netIncomeTooSmallForPlan}
 
 class HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec extends ItSpec {
+
+  override val overrideConfig: Map[String, Any] = Map(
+    "calculatorType" -> Legacy.value
+  )
 
   def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
     AuthStub.authorise()

--- a/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
+++ b/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package pagespecs
+package pagespecs.legacycalculator
 
 import langswitch.Languages.{English, Welsh}
-import ssttpcalculator.CalculatorType.PaymentOptimised
 import testsupport.ItSpec
 import testsupport.stubs.DirectDebitStub.getBanksIsSuccessful
 import testsupport.stubs._
 import testsupport.testdata.TdAll.{defaultRemainingIncomeAfterSpending, netIncomeLargeEnoughForSingleDefaultPlan, netIncomeLargeEnoughForTwoDefaultPlans, netIncomeTooSmallForPlan}
 
-class HowMuchCanYouPayEachMonthPageSpec extends ItSpec {
-
-  override val overrideConfig: Map[String, Any] = Map(
-    "calculatorType" -> PaymentOptimised.value
-  )
+class HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec extends ItSpec {
 
   def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
     AuthStub.authorise()
@@ -99,103 +94,15 @@ class HowMuchCanYouPayEachMonthPageSpec extends ItSpec {
       howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
     }
   }
-  "displays custom amount option" - {
+  "does not display a custom amount option" - {
     "in English" in {
       beginJourney()
-      howMuchCanYouPayEachMonthPage.customAmountOptionIsDisplayed
+      howMuchCanYouPayEachMonthPage.customAmountOptionNotDisplayed
     }
     "in Welsh" in {
       beginJourney()
       howMuchCanYouPayEachMonthPage.clickOnWelshLink()
-      howMuchCanYouPayEachMonthPage.customAmountOptionIsDisplayed(Welsh)
-    }
-  }
-  "custom amount entry" - {
-    "displays page with custom option at top when custom amount entered and continue pressed" in {
-      beginJourney()
-
-      howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
-
-      val customAmount = 280
-      val planMonths = 18
-      val planInterest = 124.26
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount(customAmount.toString)
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertPageWithCustomAmountIsDisplayed(customAmount.toString, Some(planMonths.toString), Some(planInterest.toString))
-    }
-    "less than minimum displays error message" in {
-      beginJourney()
-
-      val customAmountBelowMinimum = 200
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount(customAmountBelowMinimum.toString)
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertBelowMinimumErrorIsDisplayed
-    }
-    "more than maximum displays error message" in {
-      beginJourney()
-
-      val customAmountBelowMinimum = 7000
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount(customAmountBelowMinimum.toString)
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertAboveMaximumErrorIsDisplayed
-    }
-    "not filled in displays error message" in {
-      beginJourney()
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount()
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertNoInputErrorIsDisplayed
-    }
-    "filled with non-numeric displays error message" in {
-      beginJourney()
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount("non-numeric")
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertNonNumericErrorIsDisplayed
-    }
-    "filled with negative amount displays error message" in {
-      beginJourney()
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount("-1")
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.assertNegativeAmountErrorIsDisplayed
-    }
-    "filled with more than two decimal places" - {
-      "in English" in {
-        beginJourney()
-
-        howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-        howMuchCanYouPayEachMonthPage.enterCustomAmount("280.111")
-        howMuchCanYouPayEachMonthPage.clickContinue()
-
-        howMuchCanYouPayEachMonthPage.assertDecimalPlacesErrorIsDisplayed
-      }
-      "in Welsh" in {
-        beginJourney()
-
-        howMuchCanYouPayEachMonthPage.clickOnWelshLink()
-        howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-        howMuchCanYouPayEachMonthPage.enterCustomAmount("280.111")
-        howMuchCanYouPayEachMonthPage.clickContinue()
-
-        howMuchCanYouPayEachMonthPage.assertDecimalPlacesErrorIsDisplayed(Welsh)
-      }
-
+      howMuchCanYouPayEachMonthPage.customAmountOptionNotDisplayed(Welsh)
     }
   }
 
@@ -234,34 +141,6 @@ class HowMuchCanYouPayEachMonthPageSpec extends ItSpec {
       checkYourPaymentPlanPage.goBack()
 
       howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
-    }
-    "selecting a custom option, continue, back to change income or spending, resets previous plan selection - doesn't display previous selection" in {
-      beginJourney()
-
-      val customAmount = 280
-      val planMonths = 18
-      val planInterest = 124.26
-
-      howMuchCanYouPayEachMonthPage.selectCustomAmountOption()
-      howMuchCanYouPayEachMonthPage.enterCustomAmount(customAmount.toString)
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.optionIsDisplayed(customAmount.toString, Some(planMonths.toString), Some(planInterest.toString))
-
-      howMuchCanYouPayEachMonthPage.selectASpecificOption("0")
-      howMuchCanYouPayEachMonthPage.clickContinue()
-
-      checkYourPaymentPlanPage.goBack()
-      howMuchCanYouPayEachMonthPage.clickOnBackLink()
-
-      howMuchYouCouldAffordPage.clickOnAddChangeIncome()
-      yourMonthlyIncomePage.enterMonthlyIncome("501")
-      yourMonthlyIncomePage.clickContinue()
-
-      howMuchYouCouldAffordPage.clickContinue()
-
-      howMuchCanYouPayEachMonthPage.optionIsNotDisplayed(customAmount.toString, Some(planMonths.toString), Some(planInterest.toString))
-
     }
   }
 }

--- a/test/pagespecs/pages/HowMuchCanYouPayEachMonthPage.scala
+++ b/test/pagespecs/pages/HowMuchCanYouPayEachMonthPage.scala
@@ -102,6 +102,12 @@ class HowMuchCanYouPayEachMonthPage(baseUrl: BaseUrl)(implicit webDriver: WebDri
     ()
   }
 
+  def customAmountOptionNotDisplayed(implicit lang: Language = Languages.English): Unit = probing {
+    val expectedLines = Expected.MainText.CustomOption().stripSpaces().split("\n")
+    assertContentDoesNotContainLines(expectedLines)
+    ()
+  }
+
   def assertPageWithCustomAmountIsDisplayed(amount:   String,
                                             months:   Option[String] = None,
                                             interest: Option[String] = None
@@ -178,8 +184,6 @@ class HowMuchCanYouPayEachMonthPage(baseUrl: BaseUrl)(implicit webDriver: WebDri
              |Includes total interest estimated at £116.53
              |£400 per month over 13 months
              |Includes total interest estimated at £89.39
-             |A different monthly amount
-             |Enter an amount that is at least £250 but no more than
              |I cannot afford to make these payments
              |You may still be able to set up a payment plan over the phone. Call us on 0300 123 1813 to discuss your debt.
              |Continue
@@ -195,8 +199,6 @@ class HowMuchCanYouPayEachMonthPage(baseUrl: BaseUrl)(implicit webDriver: WebDri
              |Mae hyn yn cynnwys cyfanswm y llog wedi’i amcangyfrif, sef £116.53
              |£400 y mis, am 13 mis
              |Mae hyn yn cynnwys cyfanswm y llog wedi’i amcangyfrif, sef £89.39
-             |Swm misol gwahanol
-             |Rhowch swm sydd o leiaf £250 ond heb fod yn fwy na
              |Nid wyf yn gallu fforddio’r taliadau hyn
              |Mae’n bosibl y byddwch yn dal i allu trefnu cynllun talu dros y ffôn. Ffoniwch Wasanaeth Cwsmeriaid Cymraeg CThEF ar 0300 200 1900 i drafod eich opsiynau.
              |Yn eich blaen

--- a/test/testsupport/ItSpec.scala
+++ b/test/testsupport/ItSpec.scala
@@ -48,6 +48,8 @@ class ItSpec
   implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout  = scaled(Span(300, Millis)), interval = scaled(Span(2, Seconds)))
 
+  val overrideConfig: Map[String, Any] = Map.empty
+
   protected lazy val configMap: Map[String, Any] = Map(
     "microservice.services.direct-debit.port" -> WireMockSupport.port,
     "microservice.services.time-to-pay-arrangement.port" -> WireMockSupport.port,
@@ -62,7 +64,7 @@ class ItSpec
     "microservice.services.identity-verification-frontend.uplift-url" -> s"http://localhost:${WireMockSupport.port}/mdtp/uplift",
     "microservice.services.identity-verification-frontend.callback.base-url" -> s"http://localhost:${testPort}",
     "microservice.services.identity-verification-frontend.callback.complete-path" -> "/pay-what-you-owe-in-instalments/arrangement/determine-eligibility",
-    "microservice.services.identity-verification-frontend.callback.reject-path" -> "/pay-what-you-owe-in-instalments/eligibility/not-enrolled")
+    "microservice.services.identity-verification-frontend.callback.reject-path" -> "/pay-what-you-owe-in-instalments/eligibility/not-enrolled") ++ overrideConfig
 
   //in tests use `app`
   override def fakeApplication(): Application = new GuiceApplicationBuilder()
@@ -118,7 +120,6 @@ class ItSpec
   lazy val howMuchYouCouldAffordPage: HowMuchYouCouldAffordPage = wire[HowMuchYouCouldAffordPage]
   lazy val weCannotAgreeYourPaymentPlanPage: WeCannotAgreeYourPaymentPlanPage = wire[WeCannotAgreeYourPaymentPlanPage]
   lazy val howMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage = wire[HowMuchCanYouPayEachMonthPage]
-  //  lazy val calculatorInstalmentsPage11thDay: CalculatorInstalmentsPage11thDay = wire[CalculatorInstalmentsPage11thDay]
   lazy val selectDatePage: InstalmentSummarySelectDatePage = wire[InstalmentSummarySelectDatePage]
   lazy val checkYourPaymentPlanPage: CheckYourPaymentPlanPageForPaymentDay28thOfMonth =
     wire[CheckYourPaymentPlanPageForPaymentDay28thOfMonth]


### PR DESCRIPTION
- Add calculator type feature switch (`Legacy` and `PaymentOptimised`)
- Remove custom amount input option from 'How much do you want to pay each month' page for Legacy calculator type
- Set calculator type in config to Legacy
- Update tests to cover both options