### PR TITLE
[AM][OPS-10226] Allow for 24 month plans on Legacy calculator

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -62,6 +62,7 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig) {
     (s"$baseUrl$completePath", s"$baseUrl$failurePath")
   }
 
+  // Config for payment dates - PaymentOptimised calculator ONLY
   lazy val minimumLengthOfPaymentPlan: Int = servicesConfig.getInt("paymentDatesConfig.minimumLengthOfPaymentPlan")
   lazy val maximumLengthOfPaymentPlan: Int = servicesConfig.getInt("paymentDatesConfig.maximumLengthOfPaymentPlan")
   lazy val daysToProcessFirstPayment: Int = servicesConfig.getInt("paymentDatesConfig.daysToProcessPayment")
@@ -75,4 +76,7 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig) {
     case CalculatorType.PaymentOptimised.value => CalculatorType.PaymentOptimised
     case otherValue                            => throw new Exception(s"calculator type '$otherValue' in config not recognised")
   }
+
+  //Config for Legacy calculator
+  lazy val legacyMaxLengthOfPaymentPlan: Int = servicesConfig.getInt("legacyCalculatorConfig.maximumLengthOfPaymentPlan")
 }

--- a/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
+++ b/app/views/calculator/legacy/how_much_can_you_pay_each_month_form_legacy.scala.html
@@ -69,7 +69,8 @@
 
 @main(
     title = Messages("ssttp.calculator.results.title"),
-    hasErrors = selectPlanForm.hasErrors
+    hasErrors = selectPlanForm.hasErrors,
+    backButtonUrl = Some(ssttpaffordability.routes.AffordabilityController.getHowMuchYouCouldAfford())
 ) {
 
 <section class="govuk-body">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,7 +54,7 @@ play.http.errorHandler = "controllers.ErrorHandler"
 # Config for calculator (Legacy or PaymentOptimised)
 calculatorType = Legacy
 
-# Config for payment dates
+# Config for payment dates - PaymentOptimised calculator ONLY
 paymentDatesConfig {
   minimumLengthOfPaymentPlan = 1
   maximumLengthOfPaymentPlan = 24
@@ -63,6 +63,11 @@ paymentDatesConfig {
   firstPaymentDayOfMonth = 1
   lastPaymentDayOfMonth = 28
   lastPaymentDelayDays = 7
+}
+
+# Config for Legacy calculator
+legacyCalculatorConfig {
+    maximumLengthOfPaymentPlan = 24
 }
 
 

--- a/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
+++ b/test/pagespecs/legacycalculator/HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec.scala
@@ -124,6 +124,11 @@ class HowMuchCanYouPayEachMonthPageLegacyCalculatorSpec extends ItSpec with Lega
     howMuchCanYouPayEachMonthPageLegacyCalculator.assertInitialPageIsDisplayed(English)
   }
 
+  "back button" in {
+    beginJourney()
+    howMuchCanYouPayEachMonthPageLegacyCalculator.backButtonHref shouldBe Some(s"${baseUrl.value}${howMuchYouCouldAffordPage.path}")
+  }
+
   "select an option and continue" - {
     "basic case" in {
       beginJourney()

--- a/test/ssttpcalculator/CalculatorControllerSpec.scala
+++ b/test/ssttpcalculator/CalculatorControllerSpec.scala
@@ -1,10 +1,24 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package ssttpcalculator
 
 import akka.util.Timeout
 import journey.Statuses.InProgress
-import journey.{Journey, JourneyId, JourneyService, PaymentToday, PaymentTodayAmount}
-import org.scalatest.Assertion
+import journey.{Journey, JourneyId, JourneyService}
 import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
@@ -12,26 +26,44 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.http.Status
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsString, redirectLocation, status}
+import play.api.test.Helpers.{redirectLocation, status}
 import ssttpaffordability.model.Expense.HousingExp
 import ssttpaffordability.model.{Expenses, Income, IncomeBudgetLine, Spending}
 import ssttpaffordability.model.IncomeCategory.MonthlyIncome
 import testsupport.RichMatchers.eventually
 import testsupport.stubs.{ArrangementStub, AuthStub, DirectDebitStub, TaxpayerStub}
-import testsupport.testdata.TdAll.selectedRegularPaymentAmount300
 import testsupport.testdata.{TdAll, TdRequest}
 import testsupport.{RichMatchers, WireMockSupport}
 import uk.gov.hmrc.http.SessionKeys
-import uk.gov.hmrc.selfservicetimetopay.models.{BankDetails, EligibilityStatus, PaymentDayOfMonth, PlanSelection, SelectedPlan, TypeOfAccountDetails}
+import uk.gov.hmrc.selfservicetimetopay.models.{BankDetails, EligibilityStatus, PaymentDayOfMonth, TypeOfAccountDetails}
 import _root_.model.enumsforforms.TypesOfBankAccount.Personal
 import _root_.model.enumsforforms.TypesOfBankAccount
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
-import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.mvc.Result
 
 import java.time.LocalDateTime
 import java.util.UUID
+import scala.concurrent.Future
+
+class CalculatorControllerMaxLengthPlan12 extends CalculatorControllerSpec {
+  override def configuredMaxLengthOfPaymentPlan: Int = 12
+
+  override protected def createJourneyWithMaxLengthPlan(journeyId: JourneyId): Journey = {
+    createBaseJourney(journeyId)
+      .copy(maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 1020))))
+      .copy(maybeSpending = Some(Spending(Expenses(HousingExp, 200))))
+  }
+
+  override protected def createJourneyNoAffordablePlan(journeyId: JourneyId): Journey = {
+    createBaseJourney(journeyId)
+      .copy(maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 1000))))
+      .copy(maybeSpending = Some(Spending(Expenses(HousingExp, 200))))
+  }
+}
 
 class CalculatorControllerSpec extends PlaySpec with GuiceOneAppPerTest with WireMockSupport {
+
+  def configuredMaxLengthOfPaymentPlan: Int = 24
 
   import TdRequest._
 
@@ -40,7 +72,8 @@ class CalculatorControllerSpec extends PlaySpec with GuiceOneAppPerTest with Wir
   val testPort: Int = 19001
 
   val overrideConfig: Map[String, Any] = Map(
-    "calculatorType" -> CalculatorType.Legacy.value
+    "calculatorType" -> CalculatorType.Legacy.value,
+    "legacyCalculatorConfig.maximumLengthOfPaymentPlan" -> configuredMaxLengthOfPaymentPlan
   )
 
   protected lazy val configMap: Map[String, Any] = Map(
@@ -63,27 +96,25 @@ class CalculatorControllerSpec extends PlaySpec with GuiceOneAppPerTest with Wir
     .configure(configMap)
     .build()
 
-  val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
-
+  val requestTimeOut = 5
 
   "CalculatorController.getCalculatorInstalments" should {
-    "display 'how much can you pay each month' page if at least one plan no longer than configurable maximum length" when {
-      testConfigMaxLengths.foreach { configuredMaxLength =>
-        s"maximum length of payment plan is set to $configuredMaxLength months" in {
-          testControllerRoutingToHowMuchCanYouPay(configuredMaxLength)
-        }
+    "display 'how much can you pay each month' page if at least one plan no longer than configurable maximum length" in {
+      eventually(RichMatchers.timeout(Span(requestTimeOut, Seconds))) {
+        val res = testGetCalculateInstalments(createJourneyWithMaxLengthPlan)
+        status(res) mustBe Status.OK
       }
     }
-    "display 'we cannot agree your payment plan' page if no plan is within the configurable maximum length" when {
-      testConfigMaxLengths.foreach { configuredMaxLength =>
-        s"maximum length of payment plan is set to $configuredMaxLength months" in {
-          testControllerRoutingToCannotAgreePlan(configuredMaxLength)
-        }
+    "display 'we cannot agree your payment plan' page if no plan is within the configurable maximum length" in {
+      eventually(RichMatchers.timeout(Span(requestTimeOut, Seconds))) {
+        val res = testGetCalculateInstalments(createJourneyNoAffordablePlan)
+        status(res) mustBe Status.SEE_OTHER
+        redirectLocation(res) mustBe Some("/pay-what-you-owe-in-instalments/we-cannot-agree-your-payment-plan")
       }
     }
   }
 
-  def testControllerRoutingToHowMuchCanYouPay (configuredMaxLength: Int): Assertion = {
+  private def testGetCalculateInstalments(createJourney: JourneyId => Journey): Future[Result] = {
     AuthStub.authorise()
 
     DirectDebitStub.postPaymentPlan
@@ -94,77 +125,38 @@ class CalculatorControllerSpec extends PlaySpec with GuiceOneAppPerTest with Wir
     val sessionId = UUID.randomUUID().toString
     val fakeRequest = FakeRequest().withAuthToken().withSession(SessionKeys.sessionId -> sessionId, "ssttp.journeyId" -> journeyId.toHexString)
 
-    val journey = createSuccessJourney(journeyId)
+    val journey = createJourney(journeyId)
     val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
     journeyService.saveJourney(journey)(fakeRequest)
 
     val controller: CalculatorController = app.injector.instanceOf[CalculatorController]
 
-
-
-    eventually(RichMatchers.timeout(Span(5, Seconds))) {
-      val res = controller.getCalculateInstalments()(fakeRequest)
-      status(res) mustBe Status.OK
-    }
+    controller.getCalculateInstalments()(fakeRequest)
   }
 
-
-  def testControllerRoutingToCannotAgreePlan(configuredMaxLength: Int): Assertion = {
-    AuthStub.authorise()
-
-    DirectDebitStub.postPaymentPlan
-    ArrangementStub.postTtpArrangement
-    TaxpayerStub.getTaxpayer()
-
-    val journeyId = JourneyId("62ce7631b7602426d74f83b0")
-    val sessionId = UUID.randomUUID().toString
-    val fakeRequest = FakeRequest().withAuthToken().withSession(SessionKeys.sessionId -> sessionId, "ssttp.journeyId" -> journeyId.toHexString)
-
-    val journey = createFailJourney(journeyId)
-    val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
-    journeyService.saveJourney(journey)(fakeRequest)
-
-    val controller: CalculatorController = app.injector.instanceOf[CalculatorController]
-
-
-    eventually(RichMatchers.timeout(Span(5, Seconds))) {
-      val res = controller.getCalculateInstalments()(fakeRequest)
-      println(s"res: $res")
-      status(res) mustBe Status.SEE_OTHER
-      redirectLocation(res) mustBe Some("/pay-what-you-owe-in-instalments/we-cannot-agree-your-payment-plan")
-
-    }
+  protected def createJourneyWithMaxLengthPlan(journeyId: JourneyId): Journey = {
+    createBaseJourney(journeyId)
+      .copy(maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 620))))
+      .copy(maybeSpending = Some(Spending(Expenses(HousingExp, 200))))
   }
 
-  private def createSuccessJourney(journeyId: JourneyId): Journey = {
+  protected def createJourneyNoAffordablePlan(journeyId: JourneyId): Journey = {
+    createBaseJourney(journeyId)
+      .copy(maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 600))))
+      .copy(maybeSpending = Some(Spending(Expenses(HousingExp, 200))))
+  }
+
+  protected def createBaseJourney(journeyId: JourneyId): Journey = {
     Journey(
-      _id = journeyId,
-      status = InProgress,
-      createdOn = LocalDateTime.now(),
+      _id                       = journeyId,
+      status                    = InProgress,
+      createdOn                 = LocalDateTime.now(),
       maybeTypeOfAccountDetails = Some(TypeOfAccountDetails(TypesOfBankAccount.Personal, isAccountHolder = true)),
-      maybeBankDetails = Some(BankDetails(Some(Personal), "111111", "12345678", "Darth Vader", None)),
-      existingDDBanks = None,
-      maybeTaxpayer = Some(TdAll.taxpayer),
-      maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 1000))),
-      maybeSpending = Some(Spending(Expenses(HousingExp, 200))),
-      maybePaymentDayOfMonth = Some(PaymentDayOfMonth(28)),
-      maybeEligibilityStatus = Some(EligibilityStatus(Seq.empty))
-    )
-  }
-
-  private def createFailJourney(journeyId: JourneyId): Journey = {
-    Journey(
-      _id = journeyId,
-      status = InProgress,
-      createdOn = LocalDateTime.now(),
-      maybeTypeOfAccountDetails = Some(TypeOfAccountDetails(TypesOfBankAccount.Personal, isAccountHolder = true)),
-      maybeBankDetails = Some(BankDetails(Some(Personal), "111111", "12345678", "Darth Vader", None)),
-      existingDDBanks = None,
-      maybeTaxpayer = Some(TdAll.taxpayer),
-      maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 300))),
-      maybeSpending = Some(Spending(Expenses(HousingExp, 200))),
-      maybePaymentDayOfMonth = Some(PaymentDayOfMonth(28)),
-      maybeEligibilityStatus = Some(EligibilityStatus(Seq.empty))
+      maybeBankDetails          = Some(BankDetails(Some(Personal), "111111", "12345678", "Darth Vader", None)),
+      existingDDBanks           = None,
+      maybeTaxpayer             = Some(TdAll.taxpayer),
+      maybePaymentDayOfMonth    = Some(PaymentDayOfMonth(28)),
+      maybeEligibilityStatus    = Some(EligibilityStatus(Seq.empty))
     )
   }
 }

--- a/test/ssttpcalculator/CalculatorControllerSpec.scala
+++ b/test/ssttpcalculator/CalculatorControllerSpec.scala
@@ -1,0 +1,170 @@
+
+package ssttpcalculator
+
+import akka.util.Timeout
+import journey.Statuses.InProgress
+import journey.{Journey, JourneyId, JourneyService, PaymentToday, PaymentTodayAmount}
+import org.scalatest.Assertion
+import org.scalatest.time.{Seconds, Span}
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsString, redirectLocation, status}
+import ssttpaffordability.model.Expense.HousingExp
+import ssttpaffordability.model.{Expenses, Income, IncomeBudgetLine, Spending}
+import ssttpaffordability.model.IncomeCategory.MonthlyIncome
+import testsupport.RichMatchers.eventually
+import testsupport.stubs.{ArrangementStub, AuthStub, DirectDebitStub, TaxpayerStub}
+import testsupport.testdata.TdAll.selectedRegularPaymentAmount300
+import testsupport.testdata.{TdAll, TdRequest}
+import testsupport.{RichMatchers, WireMockSupport}
+import uk.gov.hmrc.http.SessionKeys
+import uk.gov.hmrc.selfservicetimetopay.models.{BankDetails, EligibilityStatus, PaymentDayOfMonth, PlanSelection, SelectedPlan, TypeOfAccountDetails}
+import _root_.model.enumsforforms.TypesOfBankAccount.Personal
+import _root_.model.enumsforforms.TypesOfBankAccount
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import play.api.http.Status.{OK, SEE_OTHER}
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+class CalculatorControllerSpec extends PlaySpec with GuiceOneAppPerTest with WireMockSupport {
+
+  import TdRequest._
+
+  implicit val timeout: Timeout = Timeout(5.seconds)
+
+  val testPort: Int = 19001
+
+  val overrideConfig: Map[String, Any] = Map(
+    "calculatorType" -> CalculatorType.Legacy.value
+  )
+
+  protected lazy val configMap: Map[String, Any] = Map(
+    "microservice.services.direct-debit.port" -> WireMockSupport.port,
+    "microservice.services.time-to-pay-arrangement.port" -> WireMockSupport.port,
+    "microservice.services.time-to-pay-taxpayer.port" -> WireMockSupport.port,
+    "microservice.services.campaign-manager.port" -> WireMockSupport.port,
+    "microservice.services.ia.port" -> WireMockSupport.port,
+    "microservice.services.auth.port" -> WireMockSupport.port,
+    "microservice.services.company-auth.url" -> s"http://localhost:${WireMockSupport.port}",
+    "microservice.services.auth.login-callback.base-url" -> s"http://localhost:$testPort",
+    "microservice.services.add-taxes.port" -> WireMockSupport.port,
+    "microservice.services.bars.port" -> WireMockSupport.port,
+    "microservice.services.identity-verification-frontend.uplift-url" -> s"http://localhost:${WireMockSupport.port}/mdtp/uplift",
+    "microservice.services.identity-verification-frontend.callback.base-url" -> s"http://localhost:$testPort",
+    "microservice.services.identity-verification-frontend.callback.complete-path" -> "/pay-what-you-owe-in-instalments/arrangement/determine-eligibility",
+    "microservice.services.identity-verification-frontend.callback.reject-path" -> "/pay-what-you-owe-in-instalments/eligibility/not-enrolled") ++ overrideConfig
+
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
+    .configure(configMap)
+    .build()
+
+  val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
+
+
+  "CalculatorController.getCalculatorInstalments" should {
+    "display 'how much can you pay each month' page if at least one plan no longer than configurable maximum length" when {
+      testConfigMaxLengths.foreach { configuredMaxLength =>
+        s"maximum length of payment plan is set to $configuredMaxLength months" in {
+          testControllerRoutingToHowMuchCanYouPay(configuredMaxLength)
+        }
+      }
+    }
+    "display 'we cannot agree your payment plan' page if no plan is within the configurable maximum length" when {
+      testConfigMaxLengths.foreach { configuredMaxLength =>
+        s"maximum length of payment plan is set to $configuredMaxLength months" in {
+          testControllerRoutingToCannotAgreePlan(configuredMaxLength)
+        }
+      }
+    }
+  }
+
+  def testControllerRoutingToHowMuchCanYouPay (configuredMaxLength: Int): Assertion = {
+    AuthStub.authorise()
+
+    DirectDebitStub.postPaymentPlan
+    ArrangementStub.postTtpArrangement
+    TaxpayerStub.getTaxpayer()
+
+    val journeyId = JourneyId("62ce7631b7602426d74f83b0")
+    val sessionId = UUID.randomUUID().toString
+    val fakeRequest = FakeRequest().withAuthToken().withSession(SessionKeys.sessionId -> sessionId, "ssttp.journeyId" -> journeyId.toHexString)
+
+    val journey = createSuccessJourney(journeyId)
+    val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+    journeyService.saveJourney(journey)(fakeRequest)
+
+    val controller: CalculatorController = app.injector.instanceOf[CalculatorController]
+
+
+
+    eventually(RichMatchers.timeout(Span(5, Seconds))) {
+      val res = controller.getCalculateInstalments()(fakeRequest)
+      status(res) mustBe Status.OK
+    }
+  }
+
+
+  def testControllerRoutingToCannotAgreePlan(configuredMaxLength: Int): Assertion = {
+    AuthStub.authorise()
+
+    DirectDebitStub.postPaymentPlan
+    ArrangementStub.postTtpArrangement
+    TaxpayerStub.getTaxpayer()
+
+    val journeyId = JourneyId("62ce7631b7602426d74f83b0")
+    val sessionId = UUID.randomUUID().toString
+    val fakeRequest = FakeRequest().withAuthToken().withSession(SessionKeys.sessionId -> sessionId, "ssttp.journeyId" -> journeyId.toHexString)
+
+    val journey = createFailJourney(journeyId)
+    val journeyService: JourneyService = app.injector.instanceOf[JourneyService]
+    journeyService.saveJourney(journey)(fakeRequest)
+
+    val controller: CalculatorController = app.injector.instanceOf[CalculatorController]
+
+
+    eventually(RichMatchers.timeout(Span(5, Seconds))) {
+      val res = controller.getCalculateInstalments()(fakeRequest)
+      println(s"res: $res")
+      status(res) mustBe Status.SEE_OTHER
+      redirectLocation(res) mustBe Some("/pay-what-you-owe-in-instalments/we-cannot-agree-your-payment-plan")
+
+    }
+  }
+
+  private def createSuccessJourney(journeyId: JourneyId): Journey = {
+    Journey(
+      _id = journeyId,
+      status = InProgress,
+      createdOn = LocalDateTime.now(),
+      maybeTypeOfAccountDetails = Some(TypeOfAccountDetails(TypesOfBankAccount.Personal, isAccountHolder = true)),
+      maybeBankDetails = Some(BankDetails(Some(Personal), "111111", "12345678", "Darth Vader", None)),
+      existingDDBanks = None,
+      maybeTaxpayer = Some(TdAll.taxpayer),
+      maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 1000))),
+      maybeSpending = Some(Spending(Expenses(HousingExp, 200))),
+      maybePaymentDayOfMonth = Some(PaymentDayOfMonth(28)),
+      maybeEligibilityStatus = Some(EligibilityStatus(Seq.empty))
+    )
+  }
+
+  private def createFailJourney(journeyId: JourneyId): Journey = {
+    Journey(
+      _id = journeyId,
+      status = InProgress,
+      createdOn = LocalDateTime.now(),
+      maybeTypeOfAccountDetails = Some(TypeOfAccountDetails(TypesOfBankAccount.Personal, isAccountHolder = true)),
+      maybeBankDetails = Some(BankDetails(Some(Personal), "111111", "12345678", "Darth Vader", None)),
+      existingDDBanks = None,
+      maybeTaxpayer = Some(TdAll.taxpayer),
+      maybeIncome = Some(Income(IncomeBudgetLine(MonthlyIncome, 300))),
+      maybeSpending = Some(Spending(Expenses(HousingExp, 200))),
+      maybePaymentDayOfMonth = Some(PaymentDayOfMonth(28)),
+      maybeEligibilityStatus = Some(EligibilityStatus(Seq.empty))
+    )
+  }
+}

--- a/test/ssttpcalculator/MaximumPaymentPlanLengthConfigSpec.scala
+++ b/test/ssttpcalculator/MaximumPaymentPlanLengthConfigSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssttpcalculator
+
+import config.AppConfig
+import org.scalatest.Assertion
+import play.api.Application
+import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+import play.api.test.FakeRequest
+import ssttpcalculator.model.PaymentsCalendar
+import testsupport.ItSpec
+import times.ClockProvider
+import timetopaytaxpayer.cor.model.{CommunicationPreferences, SaUtr, SelfAssessmentDetails, Debit => corDebit}
+
+import java.time.LocalDate
+
+class MaximumPaymentPlanLengthConfigSpec extends ItSpec {
+
+  val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
+
+  "PaymentsCalendar" - {
+    "generates regular payment dates whose number is equal to the configurable maximum length of payment plan" - {
+      testConfigMaxLengths.foreach { configuredMaxLength =>
+        s"when maximum length of payment plan is set to $configuredMaxLength months" in {
+          testPaymentsCalendarMaximumLength(configuredMaxLength)
+        }
+      }
+    }
+  }
+
+  "PaymentPlansService.defaultSchedules" - {
+    "generates plans up to the configurable maximum length but no more" - {
+      testConfigMaxLengths.foreach { configuredMaxLength =>
+        s"when maximum length of payment plan is set to $configuredMaxLength months" - {
+          s"$configuredMaxLength month plan is generated" in {
+            testDefaultSchedulesCanGenerateMaximumLength(configuredMaxLength)
+          }
+          s"${configuredMaxLength + 1} month plan is NOT generated" in {
+            testDefaultSchedulesWillNotExceedMaximumLength(configuredMaxLength)
+          }
+        }
+      }
+    }
+  }
+
+  private def testPaymentsCalendarMaximumLength(configuredMaxLength: Int): Assertion = {
+    val config: AppConfig = fakeApplicationConfigOverride(
+      Map("paymentDatesConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
+    ).injector.instanceOf[AppConfig]
+
+    val result = PaymentsCalendar.generate(0, date("2000-02-05"))(config)
+
+    result.regularPaymentDates.length shouldEqual configuredMaxLength
+  }
+
+  private def testDefaultSchedulesCanGenerateMaximumLength(configuredMaxLength: Int): Assertion = {
+    val paymentPlansService: PaymentPlansService = fakeApplicationConfigOverride(
+      Map("paymentDatesConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
+    ).injector.instanceOf[PaymentPlansService]
+
+    val request = FakeRequest()
+
+    val clock = new ClockProvider
+    val nowDate = clock.nowDate()(request)
+
+    val initialPayment = 0
+    val preferredPaymentDay = None
+    val remainingIncomeAfterSpending = 400
+
+    val sa = SelfAssessmentDetails(
+      SaUtr("saUtr"),
+      CommunicationPreferences(false, false, false, false),
+      Seq(corDebit("originCode",
+        remainingIncomeAfterSpending * configuredMaxLength / 2,
+        nowDate.plusMonths(configuredMaxLength + 3), None, nowDate
+      )),
+      Seq()
+    )
+
+    val result = paymentPlansService.defaultSchedules(sa, initialPayment, preferredPaymentDay, remainingIncomeAfterSpending)(request)
+    result.toSeq.length shouldBe 3
+  }
+
+  private def testDefaultSchedulesWillNotExceedMaximumLength(configuredMaxLength: Int): Assertion = {
+    val paymentPlansService: PaymentPlansService = fakeApplicationConfigOverride(
+      Map("paymentDatesConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
+    ).injector.instanceOf[PaymentPlansService]
+
+    val request = FakeRequest()
+
+    val clock = new ClockProvider
+    val nowDate = clock.nowDate()(request)
+
+    val initialPayment = 0
+    val preferredPaymentDay = None
+    val remainingIncomeAfterSpending = 400
+
+    val sa = SelfAssessmentDetails(
+      SaUtr("saUtr"),
+      CommunicationPreferences(false, false, false, false),
+      Seq(corDebit("originCode",
+        (remainingIncomeAfterSpending * configuredMaxLength / 2) + 1,
+        nowDate.plusMonths(configuredMaxLength + 3),
+        None,
+        nowDate
+      )),
+      Seq()
+    )
+
+    val result = paymentPlansService.defaultSchedules(sa, initialPayment, preferredPaymentDay, remainingIncomeAfterSpending)(request)
+    result.toSeq.length shouldBe 0
+  }
+
+  private def fakeApplicationConfigOverride(overrideConfig: Map[String, Any]): Application = new GuiceApplicationBuilder()
+    .overrides(GuiceableModule.fromGuiceModules(Seq(module)))
+    .configure(configMap ++ overrideConfig)
+    .build()
+
+  private def date(date: String): LocalDate = LocalDate.parse(date)
+
+}

--- a/test/ssttpcalculator/MaximumPlanLengthConfigSpec.scala
+++ b/test/ssttpcalculator/MaximumPlanLengthConfigSpec.scala
@@ -18,14 +18,16 @@ package ssttpcalculator
 
 import config.AppConfig
 import org.scalatest.Assertion
-
+import org.scalatest.time.{Seconds, Span}
+import play.api.mvc.Results.Status
 import play.api.test.FakeRequest
+import play.api.test.Helpers.status
 import ssttpcalculator.model.PaymentsCalendar
-import testsupport.ConfigSpec
+import testsupport.{ConfigSpec, RichMatchers}
 import times.ClockProvider
 import timetopaytaxpayer.cor.model.{CommunicationPreferences, SaUtr, SelfAssessmentDetails, Debit => corDebit}
 
-class MaximumPlanLengthConfigSpec extends ConfigSpec {
+class MaximumPlanLengthConfigSpec extends ConfigSpec{
 
   val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
 
@@ -131,5 +133,4 @@ class MaximumPlanLengthConfigSpec extends ConfigSpec {
     )(request)
     result.toSeq.length shouldBe 0
   }
-
 }

--- a/test/ssttpcalculator/MaximumPlanLengthConfigSpec.scala
+++ b/test/ssttpcalculator/MaximumPlanLengthConfigSpec.scala
@@ -27,7 +27,7 @@ import testsupport.{ConfigSpec, RichMatchers}
 import times.ClockProvider
 import timetopaytaxpayer.cor.model.{CommunicationPreferences, SaUtr, SelfAssessmentDetails, Debit => corDebit}
 
-class MaximumPlanLengthConfigSpec extends ConfigSpec{
+class MaximumPlanLengthConfigSpec extends ConfigSpec {
 
   val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
 

--- a/test/ssttpcalculator/legacy/LegacyCalculatorServiceSpec.scala
+++ b/test/ssttpcalculator/legacy/LegacyCalculatorServiceSpec.scala
@@ -46,7 +46,6 @@ class LegacyCalculatorServiceSpec extends ItSpec with Matchers with DateSupport 
 
   val calculatorService: CalculatorService = fakeApplication().injector.instanceOf[CalculatorService]
 
-
   private def clockForMay(dayInMay: Int) = {
     val formattedDay = dayInMay.formatted("%02d")
     val currentDateTime = LocalDateTime.parse(s"${_2020}-05-${formattedDay}T00:00:00.880").toInstant(UTC)

--- a/test/ssttpcalculator/legacy/LegacyCalculatorServiceSpec.scala
+++ b/test/ssttpcalculator/legacy/LegacyCalculatorServiceSpec.scala
@@ -17,19 +17,16 @@
 package ssttpcalculator.legacy
 
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import ssttpcalculator.{DurationService, InterestRateService}
 import ssttpcalculator.legacy.CalculatorService._
 import ssttpcalculator.model.{PaymentSchedule, TaxLiability}
 import ssttpcalculator.legacy.model.TaxPaymentPlan
-import testsupport.DateSupport
-import times.ClockProvider
+import testsupport.{DateSupport, ItSpec}
 
 import java.time.ZoneId.systemDefault
 import java.time.ZoneOffset.UTC
 import java.time.{Clock, LocalDate, LocalDateTime}
 
-class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSupport {
+class LegacyCalculatorServiceSpec extends ItSpec with Matchers with DateSupport {
   private def date(month: Int, day: Int): LocalDate = LocalDate.of(_2020, month, day)
   private def may(day: Int): LocalDate = date(may, day)
   private def june(day: Int): LocalDate = date(june, day)
@@ -47,14 +44,17 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
   private val initialPayment = BigDecimal(debt - minimumBalanceAfterInitialPayment)
   private val initialPaymentTooLarge = BigDecimal(468.01)
 
+  val calculatorService: CalculatorService = fakeApplication().injector.instanceOf[CalculatorService]
+
+
   private def clockForMay(dayInMay: Int) = {
     val formattedDay = dayInMay.formatted("%02d")
     val currentDateTime = LocalDateTime.parse(s"${_2020}-05-${formattedDay}T00:00:00.880").toInstant(UTC)
     Clock.fixed(currentDateTime, systemDefault)
   }
 
-  "payTodayRequest" should {
-    "return a payment schedule request" when {
+  "payTodayRequest should" - {
+    "return a payment schedule request when" - {
       "the current date is the 1st" in {
         val clock = clockForMay(_1st)
 
@@ -78,8 +78,8 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "paymentScheduleRequest" should {
-    "return a payment schedule request without an initial payment" when {
+  "paymentScheduleRequest should" - {
+    "return a payment schedule request without an initial payment when" - {
       "the current date is Friday 1st May with upcoming bank holiday" in {
         val clock = clockForMay(_1st)
         val currentDate = LocalDate.now(clock)
@@ -136,7 +136,7 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
       }
     }
 
-    "return a payment schedule request with an initial payment" when {
+    "return a payment schedule request with an initial payment when" - {
       "the current date is Friday 1st May with upcoming bank holiday" in {
         val clock = clockForMay(_1st)
         val currentDate = LocalDate.now(clock)
@@ -193,7 +193,7 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
       }
     }
 
-    "return a payment schedule request with no initial payment when the user tries to make a payment which would leave less than £32 balance" when {
+    "return a payment schedule request with no initial payment when the user tries to make a payment which would leave less than £32 balance when" - {
       "the current date is Friday 1st May with upcoming bank holiday" in {
         val clock = clockForMay(_1st)
         val currentDate = LocalDate.now(clock)
@@ -251,8 +251,8 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "changeScheduleRequest with zero duration and no initial payment" should {
-    "return a payment schedule request" when {
+  "changeScheduleRequest with zero duration and no initial payment should" - {
+    "return a payment schedule request when" - {
       "the required day of the month and the current date are the 1st" in {
         val clock = clockForMay(_1st)
 
@@ -346,8 +346,8 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "changeScheduleRequest with a duration of one month and no initial payment" should {
-    "return a payment schedule request" when {
+  "changeScheduleRequest with a duration of one month and no initial payment should" - {
+    "return a payment schedule request when" - {
       "the required day of the month and the current date are the 1st" in {
         val clock = clockForMay(_1st)
 
@@ -441,8 +441,8 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "changeScheduleRequest with zero duration and an initial payment" should {
-    "return a payment schedule request" when {
+  "changeScheduleRequest with zero duration and an initial payment should" - {
+    "return a payment schedule request when" - {
       "the required day of the month and the current date are the 1st" in {
         val clock = clockForMay(_1st)
 
@@ -536,8 +536,8 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "changeScheduleRequest with a months duration and an initial payment" should {
-    "return a payment schedule request" when {
+  "changeScheduleRequest with a months duration and an initial payment should" - {
+    "return a payment schedule request when" - {
       "the required day of the month and the current date are the 1st" in {
         val clock = clockForMay(_1st)
 
@@ -631,11 +631,11 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
     }
   }
 
-  "availablePaymentSchedules with an endDate" should {
+  "availablePaymentSchedules with an endDate should" - {
     implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
     val LastPaymentDelayDays = 7
 
-    "return a payment schedule with endDate" when {
+    "return a payment schedule with endDate when" - {
       "matching last payment date plush seven days" in {
         val startDate = LocalDate.now
         val endDate = startDate.plusMonths(3)
@@ -648,8 +648,6 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
           startDate,
           endDate,
           None)
-
-        val calculatorService = new CalculatorService(new ClockProvider(), new DurationService(), new InterestRateService())
 
         val result: PaymentSchedule = calculatorService.buildSchedule(taxPaymentPlan)
 
@@ -668,8 +666,6 @@ class LegacyCalculatorServiceSpec extends AnyWordSpec with Matchers with DateSup
           startDate,
           endDate,
           None)
-
-        val calculatorService = new CalculatorService(new ClockProvider(), new DurationService(), new InterestRateService())
 
         val result: PaymentSchedule = calculatorService.buildSchedule(taxPaymentPlan)
 

--- a/test/ssttpcalculator/legacy/LegacyMaximumPlanLengthConfigSpec.scala
+++ b/test/ssttpcalculator/legacy/LegacyMaximumPlanLengthConfigSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssttpcalculator.legacy
+
+import config.AppConfig
+import org.scalatest.Assertion
+import play.api.Application
+import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+import play.api.test.FakeRequest
+import ssttpcalculator.model.PaymentsCalendar
+import testsupport.{ConfigSpec, ItSpec}
+import times.ClockProvider
+import timetopaytaxpayer.cor.model.{CommunicationPreferences, SaUtr, SelfAssessmentDetails, Debit => corDebit}
+
+import java.time.LocalDate
+
+class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
+
+  val testConfigMaxLengths: Seq[Int] = Seq(6, 12, 24)
+
+  "CalculatorService.defaultSchedules" - {
+    "generates plans up to the configurable maximum length but no more" - {
+      testConfigMaxLengths.foreach { configuredMaxLength =>
+        s"when maximum length of payment plan is set to $configuredMaxLength months" - {
+          s"$configuredMaxLength month plan is generated" in {
+            testDefaultSchedulesCanGenerateMaximumLength(configuredMaxLength)
+          }
+          s"${configuredMaxLength + 1} month plan is NOT generated" in {
+            testDefaultSchedulesWillNotExceedMaximumLength(configuredMaxLength)
+          }
+        }
+      }
+    }
+  }
+
+  private def testDefaultSchedulesCanGenerateMaximumLength(configuredMaxLength: Int): Assertion = {
+    val calculatorService: CalculatorService = appWithConfig(
+      Map("legacyCalculatorConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
+    ).injector.instanceOf[CalculatorService]
+
+    val request = FakeRequest()
+
+    val clock = new ClockProvider
+    val nowDate = clock.nowDate()(request)
+
+    val initialPayment = 0
+    val preferredPaymentDay = None
+    val remainingIncomeAfterSpending = 400
+
+    val sa = SelfAssessmentDetails(
+      SaUtr("saUtr"),
+      CommunicationPreferences(false, false, false, false),
+      Seq(corDebit("originCode",
+        remainingIncomeAfterSpending * configuredMaxLength / 2,
+        nowDate.plusMonths(configuredMaxLength + 3), None, nowDate
+      )),
+      Seq()
+    )
+
+    val allSchedules = calculatorService.allAvailableSchedules(sa, initialPayment, preferredPaymentDay)(request)
+    val closestSchedule = calculatorService.closestSchedule(remainingIncomeAfterSpending / 2, allSchedules)
+
+    val result = calculatorService.defaultSchedules(closestSchedule, allSchedules)
+    result.toSeq.length shouldBe 3
+  }
+
+  private def testDefaultSchedulesWillNotExceedMaximumLength(configuredMaxLength: Int): Assertion = {
+    val calculatorService: CalculatorService = appWithConfig(
+      Map("legacyCalculatorConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
+    ).injector.instanceOf[CalculatorService]
+
+    val request = FakeRequest()
+
+    val clock = new ClockProvider
+    val nowDate = clock.nowDate()(request)
+
+    val initialPayment = 0
+    val preferredPaymentDay = None
+    val remainingIncomeAfterSpending = 400
+
+    val sa = SelfAssessmentDetails(
+      SaUtr("saUtr"),
+      CommunicationPreferences(false, false, false, false),
+      Seq(corDebit("originCode",
+        (remainingIncomeAfterSpending * configuredMaxLength / 2) + 1,
+        nowDate.plusMonths(configuredMaxLength + 3),
+        None,
+        nowDate
+      )),
+      Seq()
+    )
+
+    val allSchedules = calculatorService.allAvailableSchedules(sa, initialPayment, preferredPaymentDay)(request)
+
+    val closestSchedule = calculatorService.closestSchedule(remainingIncomeAfterSpending / 2, allSchedules)
+
+    val result = calculatorService.defaultSchedules(closestSchedule, allSchedules)
+    result.toSeq.length shouldBe 0
+  }
+
+}

--- a/test/ssttpcalculator/legacy/LegacyMaximumPlanLengthConfigSpec.scala
+++ b/test/ssttpcalculator/legacy/LegacyMaximumPlanLengthConfigSpec.scala
@@ -16,17 +16,11 @@
 
 package ssttpcalculator.legacy
 
-import config.AppConfig
 import org.scalatest.Assertion
-import play.api.Application
-import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
 import play.api.test.FakeRequest
-import ssttpcalculator.model.PaymentsCalendar
-import testsupport.{ConfigSpec, ItSpec}
+import testsupport.ConfigSpec
 import times.ClockProvider
 import timetopaytaxpayer.cor.model.{CommunicationPreferences, SaUtr, SelfAssessmentDetails, Debit => corDebit}
-
-import java.time.LocalDate
 
 class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
 
@@ -48,14 +42,10 @@ class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
   }
 
   private def testDefaultSchedulesCanGenerateMaximumLength(configuredMaxLength: Int): Assertion = {
-    val calculatorService: CalculatorService = appWithConfig(
-      Map("legacyCalculatorConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
-    ).injector.instanceOf[CalculatorService]
-
+    val app = appWithConfigKeyValue("legacyCalculatorConfig.maximumLengthOfPaymentPlan", configuredMaxLength)
+    val calculatorService: CalculatorService = app.injector.instanceOf[CalculatorService]
     val request = FakeRequest()
-
-    val clock = new ClockProvider
-    val nowDate = clock.nowDate()(request)
+    val nowDate = (new ClockProvider).nowDate()(request)
 
     val initialPayment = 0
     val preferredPaymentDay = None
@@ -63,7 +53,12 @@ class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
 
     val sa = SelfAssessmentDetails(
       SaUtr("saUtr"),
-      CommunicationPreferences(false, false, false, false),
+      CommunicationPreferences(
+        welshLanguageIndicator = false,
+        audioIndicator         = false,
+        largePrintIndicator    = false,
+        brailleIndicator       = false
+      ),
       Seq(corDebit("originCode",
         remainingIncomeAfterSpending * configuredMaxLength / 2,
         nowDate.plusMonths(configuredMaxLength + 3), None, nowDate
@@ -79,14 +74,10 @@ class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
   }
 
   private def testDefaultSchedulesWillNotExceedMaximumLength(configuredMaxLength: Int): Assertion = {
-    val calculatorService: CalculatorService = appWithConfig(
-      Map("legacyCalculatorConfig.maximumLengthOfPaymentPlan" -> configuredMaxLength)
-    ).injector.instanceOf[CalculatorService]
-
+    val app = appWithConfigKeyValue("legacyCalculatorConfig.maximumLengthOfPaymentPlan", configuredMaxLength)
+    val calculatorService: CalculatorService = app.injector.instanceOf[CalculatorService]
     val request = FakeRequest()
-
-    val clock = new ClockProvider
-    val nowDate = clock.nowDate()(request)
+    val nowDate = (new ClockProvider).nowDate()(request)
 
     val initialPayment = 0
     val preferredPaymentDay = None
@@ -94,7 +85,12 @@ class LegacyMaximumPlanLengthConfigSpec extends ConfigSpec {
 
     val sa = SelfAssessmentDetails(
       SaUtr("saUtr"),
-      CommunicationPreferences(false, false, false, false),
+      CommunicationPreferences(
+        welshLanguageIndicator = false,
+        audioIndicator         = false,
+        largePrintIndicator    = false,
+        brailleIndicator       = false
+      ),
       Seq(corDebit("originCode",
         (remainingIncomeAfterSpending * configuredMaxLength / 2) + 1,
         nowDate.plusMonths(configuredMaxLength + 3),

--- a/test/testsupport/ConfigSpec.scala
+++ b/test/testsupport/ConfigSpec.scala
@@ -1,0 +1,17 @@
+
+package testsupport
+
+import play.api.Application
+import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+
+import java.time.LocalDate
+
+class ConfigSpec extends ItSpec {
+  def appWithConfig(configOverride: Map[String, Any]): Application =
+    new GuiceApplicationBuilder()
+      .overrides(GuiceableModule.fromGuiceModules(Seq(module)))
+      .configure(configMap ++ configOverride)
+      .build()
+
+  def date(date: String): LocalDate = LocalDate.parse(date)
+}

--- a/test/testsupport/ConfigSpec.scala
+++ b/test/testsupport/ConfigSpec.scala
@@ -17,7 +17,7 @@
 package testsupport
 
 import play.api.Application
-import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+import play.api.inject.guice.GuiceApplicationBuilder
 
 import java.time.LocalDate
 

--- a/test/testsupport/ConfigSpec.scala
+++ b/test/testsupport/ConfigSpec.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package testsupport
 
@@ -7,10 +22,12 @@ import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
 import java.time.LocalDate
 
 class ConfigSpec extends ItSpec {
+
+  def appWithConfigKeyValue(key: String, value: Any): Application = appWithConfig(Map(key -> value))
+
   def appWithConfig(configOverride: Map[String, Any]): Application =
     new GuiceApplicationBuilder()
-      .overrides(GuiceableModule.fromGuiceModules(Seq(module)))
-      .configure(configMap ++ configOverride)
+      .configure(configOverride)
       .build()
 
   def date(date: String): LocalDate = LocalDate.parse(date)

--- a/test/testsupport/ItSpec.scala
+++ b/test/testsupport/ItSpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import pagespecs.pages._
-import pagespecs.pages.legacycalculator.HowMuchCanYouPayEachMonthPageLegacyCalculator
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
 import play.api.test.{DefaultTestServerFactory, RunningServer}
 import play.api.{Application, Mode}


### PR DESCRIPTION
Also:

- fix bug: back button into "How much can you pay each month page" when using legacy calculator feature