### PR TITLE
[AM][OPS-10191] Add calculator type feature switch selected plan recompute for downstream calls

### DIFF
--- a/app/ssttpcalculator/legacy/util/CalculatorSwitchSelectedScheduleHelper.scala
+++ b/app/ssttpcalculator/legacy/util/CalculatorSwitchSelectedScheduleHelper.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssttpcalculator.legacy.util
+
+import config.AppConfig
+import journey.Journey
+import play.api.mvc.Request
+import ssttpcalculator.CalculatorType.{PaymentOptimised, Legacy}
+import ssttpcalculator.legacy.CalculatorService
+import ssttpcalculator.model.PaymentSchedule
+import ssttpcalculator.PaymentPlansService
+
+trait CalculatorSwitchSelectedScheduleHelper {
+  val calculatorService: CalculatorService
+  val paymentPlansService: PaymentPlansService
+  implicit val appConfig: AppConfig
+
+  protected def selectedSchedule(journey: Journey)(implicit request: Request[_]): PaymentSchedule = {
+    maybeSelectedSchedule(journey).getOrElse(
+      throw new IllegalArgumentException("could not calculate a valid schedule but there should be one")
+    )
+  }
+
+  protected def maybeSelectedSchedule(journey: Journey)(implicit request: Request[_]): Option[PaymentSchedule] = {
+    appConfig.calculatorType match {
+      case Legacy => Some(calculatorService.selectedSchedule(journey))
+      case PaymentOptimised =>
+        paymentPlansService.selectedSchedule(journey)
+    }
+  }
+
+}

--- a/test/pagespecs/CheckYourPaymentPlanPageSpec.scala
+++ b/test/pagespecs/CheckYourPaymentPlanPageSpec.scala
@@ -17,6 +17,7 @@
 package pagespecs
 
 import langswitch.Languages.{English, Welsh}
+import pagespecs.pages.{CheckYourPaymentPlanPage, HowMuchCanYouPayEachMonthPage}
 import ssttpcalculator.CalculatorType.PaymentOptimised
 import ssttpcalculator.model.PaymentPlanOption
 import testsupport.ItSpec
@@ -24,11 +25,20 @@ import testsupport.stubs.DirectDebitStub.getBanksIsSuccessful
 import testsupport.stubs._
 import testsupport.testdata.TdAll.defaultRemainingIncomeAfterSpending
 
-class CheckYourPaymentPlanPageSpec extends ItSpec {
+class CheckYourPaymentPlanPageSpec extends CheckYourPaymentPlanPageBaseSpec {
 
   override val overrideConfig: Map[String, Any] = Map(
     "calculatorType" -> PaymentOptimised.value
   )
+
+  val pageUnderTest: CheckYourPaymentPlanPage = checkYourPaymentPlanPage
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage = howMuchCanYouPayEachMonthPage
+}
+
+trait CheckYourPaymentPlanPageBaseSpec extends ItSpec {
+
+  val pageUnderTest: CheckYourPaymentPlanPage
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage
 
   def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
     AuthStub.authorise()
@@ -69,67 +79,65 @@ class CheckYourPaymentPlanPageSpec extends ItSpec {
     yourMonthlySpendingPage.clickContinue()
 
     howMuchYouCouldAffordPage.clickContinue()
-    howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
-    howMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Basic)
-    howMuchCanYouPayEachMonthPage.clickContinue()
-
-    checkYourPaymentPlanPage.assertInitialPageIsDisplayed()
+    inUseHowMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
+    inUseHowMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Basic)
+    inUseHowMuchCanYouPayEachMonthPage.clickContinue()
   }
 
   "language" in {
     beginJourney()
 
-    checkYourPaymentPlanPage.clickOnWelshLink()
-    checkYourPaymentPlanPage.assertInitialPageIsDisplayed(Welsh)
+    pageUnderTest.clickOnWelshLink()
+    pageUnderTest.assertInitialPageIsDisplayed(Welsh)
 
-    checkYourPaymentPlanPage.clickOnEnglishLink()
+    pageUnderTest.clickOnEnglishLink()
 
-    checkYourPaymentPlanPage.assertInitialPageIsDisplayed(English)
+    pageUnderTest.assertInitialPageIsDisplayed(English)
   }
 
   "back button" in {
     beginJourney()
-    checkYourPaymentPlanPage.backButtonHref shouldBe Some(s"${baseUrl.value}${howMuchCanYouPayEachMonthPage.path}")
+    pageUnderTest.backButtonHref shouldBe Some(s"${baseUrl.value}${inUseHowMuchCanYouPayEachMonthPage.path}")
   }
 
   "change monthly instalments" in {
     beginJourney()
-    checkYourPaymentPlanPage.clickChangeMonthlyAmountLink()
-    howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed()
+    pageUnderTest.clickChangeMonthlyAmountLink()
+    inUseHowMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed()
   }
 
   "change collection day" in {
     beginJourney()
-    checkYourPaymentPlanPage.clickChangeCollectionDayLink()
+    pageUnderTest.clickChangeCollectionDayLink()
     selectDatePage.assertInitialPageIsDisplayed
   }
 
   "change upfront payment amount" in {
     beginJourney()
-    checkYourPaymentPlanPage.clickChangeUpfrontPaymentAnswerLink()
+    pageUnderTest.clickChangeUpfrontPaymentAnswerLink()
     paymentTodayQuestionPage.assertInitialPageIsDisplayed
   }
 
   "change upfront answer" in {
     beginJourney()
-    checkYourPaymentPlanPage.clickChangeUpfrontPaymentAmountLink()
+    pageUnderTest.clickChangeUpfrontPaymentAmountLink()
     paymentTodayQuestionPage.assertInitialPageIsDisplayed
   }
 
   "continue to the next page" in {
     beginJourney()
-    checkYourPaymentPlanPage.clickContinue()
+    pageUnderTest.clickContinue()
     aboutBankAccountPage.assertInitialPageIsDisplayed
   }
 
   "shows warning" in {
     beginJourney()
-    checkYourPaymentPlanPage.assertInitialPageIsDisplayed
-    checkYourPaymentPlanPage.clickChangeMonthlyAmountLink()
-    howMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Higher)
-    howMuchCanYouPayEachMonthPage.clickContinue()
-    checkYourPaymentPlanPage.assertWarningIsDisplayed(English)
-    checkYourPaymentPlanPage.clickOnWelshLink()
-    checkYourPaymentPlanPage.assertWarningIsDisplayed(Welsh)
+    pageUnderTest.assertInitialPageIsDisplayed
+    pageUnderTest.clickChangeMonthlyAmountLink()
+    inUseHowMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Higher)
+    inUseHowMuchCanYouPayEachMonthPage.clickContinue()
+    pageUnderTest.assertWarningIsDisplayed(English)
+    pageUnderTest.clickOnWelshLink()
+    pageUnderTest.assertWarningIsDisplayed(Welsh)
   }
 }

--- a/test/pagespecs/ViewPaymentPlanPageSpec.scala
+++ b/test/pagespecs/ViewPaymentPlanPageSpec.scala
@@ -18,6 +18,7 @@ package pagespecs
 
 import langswitch.Languages.{English, Welsh}
 import model.enumsforforms.{IsSoleSignatory, TypesOfBankAccount}
+import pagespecs.pages.{CheckYourPaymentPlanPage, HowMuchCanYouPayEachMonthPage, ViewPaymentPlanPage}
 import ssttpcalculator.CalculatorType.PaymentOptimised
 import ssttpcalculator.model.PaymentPlanOption
 import testsupport.ItSpec
@@ -26,11 +27,21 @@ import testsupport.stubs._
 import testsupport.testdata.DirectDebitTd
 import testsupport.testdata.TdAll.defaultRemainingIncomeAfterSpending
 
-class ViewPaymentPlanPageSpec extends ItSpec {
-
+class ViewPaymentPlanPageSpec extends ViewPaymentPlanPageBaseSpec {
   override val overrideConfig: Map[String, Any] = Map(
     "calculatorType" -> PaymentOptimised.value
   )
+
+  val pageUnderTest: ViewPaymentPlanPage = viewPaymentPlanPage
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage = howMuchCanYouPayEachMonthPage
+  val inUseCheckYourPaymentPlanPage: CheckYourPaymentPlanPage = checkYourPaymentPlanPage
+
+}
+
+trait ViewPaymentPlanPageBaseSpec extends ItSpec {
+  val pageUnderTest: ViewPaymentPlanPage
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage
+  val inUseCheckYourPaymentPlanPage: CheckYourPaymentPlanPage
 
   def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
     AuthStub.authorise()
@@ -73,12 +84,12 @@ class ViewPaymentPlanPageSpec extends ItSpec {
     yourMonthlySpendingPage.clickContinue()
 
     howMuchYouCouldAffordPage.clickContinue()
-    howMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
-    howMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Basic)
-    howMuchCanYouPayEachMonthPage.clickContinue()
+    inUseHowMuchCanYouPayEachMonthPage.assertInitialPageIsDisplayed
+    inUseHowMuchCanYouPayEachMonthPage.selectASpecificOption(PaymentPlanOption.Basic)
+    inUseHowMuchCanYouPayEachMonthPage.clickContinue()
 
-    checkYourPaymentPlanPage.assertInitialPageIsDisplayed()
-    checkYourPaymentPlanPage.clickContinue()
+    inUseCheckYourPaymentPlanPage.assertInitialPageIsDisplayed()
+    inUseCheckYourPaymentPlanPage.clickContinue()
 
     aboutBankAccountPage.assertInitialPageIsDisplayed()
     aboutBankAccountPage.selectTypeOfAccountRadioButton(TypesOfBankAccount.Personal)
@@ -99,7 +110,7 @@ class ViewPaymentPlanPageSpec extends ItSpec {
     beginJourney()
     termsAndConditionsPage.clickContinue()
     arrangementSummaryPage.clickLink()
-    viewPaymentPlanPage.assertInitialPageIsDisplayed(English)
+    pageUnderTest.assertInitialPageIsDisplayed(English)
   }
 
   "language Welsh" in {
@@ -107,11 +118,11 @@ class ViewPaymentPlanPageSpec extends ItSpec {
     termsAndConditionsPage.clickOnWelshLink()
     termsAndConditionsPage.clickContinue()
     arrangementSummaryPage.clickLink()
-    viewPaymentPlanPage.assertInitialPageIsDisplayed(Welsh)
+    pageUnderTest.assertInitialPageIsDisplayed(Welsh)
   }
 
   "back button" in {
     beginJourney()
-    viewPaymentPlanPage.backButtonHref shouldBe Some(s"${baseUrl.value}${ssttpdirectdebit.routes.DirectDebitController.getDirectDebitConfirmation()}")
+    pageUnderTest.backButtonHref shouldBe Some(s"${baseUrl.value}${ssttpdirectdebit.routes.DirectDebitController.getDirectDebitConfirmation()}")
   }
 }

--- a/test/pagespecs/legacycalculator/CheckYourPaymentPlanPageLegacyCalculatorSpec.scala
+++ b/test/pagespecs/legacycalculator/CheckYourPaymentPlanPageLegacyCalculatorSpec.scala
@@ -16,123 +16,17 @@
 
 package pagespecs.legacycalculator
 
-import langswitch.Languages.{English, Welsh}
+import pagespecs.CheckYourPaymentPlanPageBaseSpec
+import pagespecs.pages.{CheckYourPaymentPlanPage, HowMuchCanYouPayEachMonthPage}
 import ssttpcalculator.CalculatorType.Legacy
-import ssttpcalculator.model.PaymentPlanOption
-import testsupport.ItSpec
 import testsupport.legacycalculator.LegacyCalculatorPages
-import testsupport.stubs.DirectDebitStub.getBanksIsSuccessful
-import testsupport.stubs._
-import testsupport.testdata.TdAll.defaultRemainingIncomeAfterSpending
 
-class CheckYourPaymentPlanPageLegacyCalculatorSpec extends ItSpec with LegacyCalculatorPages {
+class CheckYourPaymentPlanPageLegacyCalculatorSpec extends CheckYourPaymentPlanPageBaseSpec with LegacyCalculatorPages {
 
   override val overrideConfig: Map[String, Any] = Map(
     "calculatorType" -> Legacy.value
   )
 
-  def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
-    AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
-    IaStub.successfulIaCheck
-    GgStub.signInPage(port)
-    getBanksIsSuccessful()
-
-    startPage.open()
-    startPage.assertInitialPageIsDisplayed()
-    startPage.clickOnStartNowButton()
-
-    taxLiabilitiesPage.assertInitialPageIsDisplayed()
-    taxLiabilitiesPage.clickOnStartNowButton()
-
-    paymentTodayQuestionPage.assertInitialPageIsDisplayed()
-    paymentTodayQuestionPage.selectRadioButton(false)
-    paymentTodayQuestionPage.clickContinue()
-
-    selectDatePage.assertInitialPageIsDisplayed()
-    selectDatePage.selectFirstOption28thDay()
-    selectDatePage.clickContinue()
-
-    startAffordabilityPage.assertInitialPageIsDisplayed()
-    startAffordabilityPage.clickContinue()
-
-    addIncomeSpendingPage.assertInitialPageIsDisplayed()
-    addIncomeSpendingPage.clickOnAddChangeIncome()
-
-    yourMonthlyIncomePage.assertInitialPageIsDisplayed
-    yourMonthlyIncomePage.enterMonthlyIncome(remainingIncomeAfterSpending.toString)
-    yourMonthlyIncomePage.clickContinue()
-
-    addIncomeSpendingPage.assertPathHeaderTitleCorrect(English)
-    addIncomeSpendingPage.clickOnAddChangeSpending()
-
-    yourMonthlySpendingPage.assertInitialPageIsDisplayed
-    yourMonthlySpendingPage.clickContinue()
-
-    howMuchYouCouldAffordPage.clickContinue()
-    howMuchCanYouPayEachMonthPageLegacyCalculator.assertInitialPageIsDisplayed
-    howMuchCanYouPayEachMonthPageLegacyCalculator.selectASpecificOption(PaymentPlanOption.Basic)
-    howMuchCanYouPayEachMonthPageLegacyCalculator.clickContinue()
-
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed()
-  }
-
-  "language" in {
-    beginJourney()
-
-    checkYourPaymentPlanPageLegacyCalculator.clickOnWelshLink()
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed(Welsh)
-
-    checkYourPaymentPlanPage.clickOnEnglishLink()
-
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed(English)
-  }
-
-  "change monthly instalments" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.clickChangeMonthlyAmountLink()
-    howMuchCanYouPayEachMonthPageLegacyCalculator.assertInitialPageIsDisplayed()
-  }
-
-  "change collection day" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.clickChangeCollectionDayLink()
-    selectDatePage.assertInitialPageIsDisplayed
-  }
-
-  "change upfront payment amount" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.clickChangeUpfrontPaymentAnswerLink()
-    paymentTodayQuestionPage.assertInitialPageIsDisplayed
-  }
-
-  "change upfront answer" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.clickChangeUpfrontPaymentAmountLink()
-    paymentTodayQuestionPage.assertInitialPageIsDisplayed
-  }
-
-  "continue to the next page" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.clickContinue()
-    aboutBankAccountPage.assertInitialPageIsDisplayed
-  }
-
-  "shows warning" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed
-    checkYourPaymentPlanPageLegacyCalculator.clickChangeMonthlyAmountLink()
-    howMuchCanYouPayEachMonthPageLegacyCalculator.selectASpecificOption(PaymentPlanOption.Higher)
-    howMuchCanYouPayEachMonthPageLegacyCalculator.clickContinue()
-    checkYourPaymentPlanPageLegacyCalculator.assertWarningIsDisplayed(English)
-    checkYourPaymentPlanPageLegacyCalculator.clickOnWelshLink()
-    checkYourPaymentPlanPageLegacyCalculator.assertWarningIsDisplayed(Welsh)
-  }
-
-  "back link goes to previous page" in {
-    beginJourney()
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed
-    checkYourPaymentPlanPageLegacyCalculator.clickOnBackButton()
-    howMuchCanYouPayEachMonthPageLegacyCalculator.assertInitialPageIsDisplayed
-  }
+  val pageUnderTest: CheckYourPaymentPlanPage = checkYourPaymentPlanPageLegacyCalculator
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage = howMuchCanYouPayEachMonthPageLegacyCalculator
 }

--- a/test/pagespecs/legacycalculator/ViewPaymentPlanPageLegacyCalculatorSpec.scala
+++ b/test/pagespecs/legacycalculator/ViewPaymentPlanPageLegacyCalculatorSpec.scala
@@ -18,6 +18,8 @@ package pagespecs.legacycalculator
 
 import langswitch.Languages.{English, Welsh}
 import model.enumsforforms.{IsSoleSignatory, TypesOfBankAccount}
+import pagespecs.ViewPaymentPlanPageBaseSpec
+import pagespecs.pages.{CheckYourPaymentPlanPage, HowMuchCanYouPayEachMonthPage, ViewPaymentPlanPage}
 import ssttpcalculator.CalculatorType.Legacy
 import ssttpcalculator.model.PaymentPlanOption
 import testsupport.ItSpec
@@ -27,95 +29,14 @@ import testsupport.stubs._
 import testsupport.testdata.DirectDebitTd
 import testsupport.testdata.TdAll.defaultRemainingIncomeAfterSpending
 
-class ViewPaymentPlanPageLegacyCalculatorSpec extends ItSpec with LegacyCalculatorPages {
+class ViewPaymentPlanPageLegacyCalculatorSpec extends ViewPaymentPlanPageBaseSpec with LegacyCalculatorPages {
 
   override val overrideConfig: Map[String, Any] = Map(
     "calculatorType" -> Legacy.value
   )
 
-  def beginJourney(remainingIncomeAfterSpending: BigDecimal = defaultRemainingIncomeAfterSpending): Unit = {
-    AuthStub.authorise()
-    TaxpayerStub.getTaxpayer()
-    IaStub.successfulIaCheck
-    GgStub.signInPage(port)
-    getBanksIsSuccessful()
-    DirectDebitStub.postPaymentPlan
-    ArrangementStub.postTtpArrangement
+  val pageUnderTest: ViewPaymentPlanPage = viewPaymentPlanPageLegacyCalculator
+  val inUseHowMuchCanYouPayEachMonthPage: HowMuchCanYouPayEachMonthPage = howMuchCanYouPayEachMonthPageLegacyCalculator
+  val inUseCheckYourPaymentPlanPage: CheckYourPaymentPlanPage = checkYourPaymentPlanPageLegacyCalculator
 
-    startPage.open()
-    startPage.assertInitialPageIsDisplayed()
-    startPage.clickOnStartNowButton()
-
-    taxLiabilitiesPage.assertInitialPageIsDisplayed()
-    taxLiabilitiesPage.clickOnStartNowButton()
-
-    paymentTodayQuestionPage.assertInitialPageIsDisplayed()
-    paymentTodayQuestionPage.selectRadioButton(false)
-    paymentTodayQuestionPage.clickContinue()
-
-    selectDatePage.assertInitialPageIsDisplayed()
-    selectDatePage.selectFirstOption28thDay()
-    selectDatePage.clickContinue()
-
-    startAffordabilityPage.assertInitialPageIsDisplayed()
-    startAffordabilityPage.clickContinue()
-
-    addIncomeSpendingPage.assertInitialPageIsDisplayed()
-    addIncomeSpendingPage.clickOnAddChangeIncome()
-
-    yourMonthlyIncomePage.assertInitialPageIsDisplayed
-    yourMonthlyIncomePage.enterMonthlyIncome(remainingIncomeAfterSpending.toString)
-    yourMonthlyIncomePage.clickContinue()
-
-    addIncomeSpendingPage.assertPathHeaderTitleCorrect(English)
-    addIncomeSpendingPage.clickOnAddChangeSpending()
-
-    yourMonthlySpendingPage.assertInitialPageIsDisplayed
-    yourMonthlySpendingPage.clickContinue()
-
-    howMuchYouCouldAffordPage.clickContinue()
-    howMuchCanYouPayEachMonthPageLegacyCalculator.assertInitialPageIsDisplayed
-    howMuchCanYouPayEachMonthPageLegacyCalculator.selectASpecificOption(PaymentPlanOption.Basic)
-    howMuchCanYouPayEachMonthPageLegacyCalculator.clickContinue()
-
-    checkYourPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed()
-    checkYourPaymentPlanPageLegacyCalculator.clickContinue()
-
-    aboutBankAccountPage.assertInitialPageIsDisplayed()
-    aboutBankAccountPage.selectTypeOfAccountRadioButton(TypesOfBankAccount.Personal)
-    aboutBankAccountPage.selectIsAccountHolderRadioButton(IsSoleSignatory.Yes)
-    aboutBankAccountPage.clickContinue()
-
-    directDebitPage.assertInitialPageIsDisplayed()
-    directDebitPage.fillOutForm(DirectDebitTd.accountName, DirectDebitTd.sortCode, DirectDebitTd.accountNumber)
-    BarsStub.validateBank(DirectDebitTd.sortCode, DirectDebitTd.accountNumber)
-    DirectDebitStub.getBanksIsSuccessful()
-    directDebitPage.clickContinue()
-
-    directDebitConfirmationPage.assertInitialPageIsDisplayed()
-    directDebitConfirmationPage.clickContinue()
-  }
-
-  "language English" in {
-    beginJourney()
-    termsAndConditionsPage.clickContinue()
-    arrangementSummaryPage.clickLink()
-    viewPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed(English)
-  }
-
-  "language Welsh" in {
-    beginJourney()
-    termsAndConditionsPage.clickOnWelshLink()
-    termsAndConditionsPage.clickContinue()
-    arrangementSummaryPage.clickLink()
-    viewPaymentPlanPageLegacyCalculator.assertInitialPageIsDisplayed(Welsh)
-  }
-
-  "back link goes to previous page" in {
-    beginJourney()
-    termsAndConditionsPage.clickContinue()
-    arrangementSummaryPage.clickLink()
-    viewPaymentPlanPageLegacyCalculator.clickOnBackButton()
-    arrangementSummaryPage.assertInitialPageIsDisplayed
-  }
 }

--- a/test/ssttparrangement/ArrangementControllerSpec.scala
+++ b/test/ssttparrangement/ArrangementControllerSpec.scala
@@ -79,7 +79,7 @@ class ArrangementControllerSpec extends PlaySpec with GuiceOneAppPerTest with Wi
 
       val controller: ArrangementController = app.injector.instanceOf[ArrangementController]
 
-      eventually(RichMatchers.timeout(Span(5, Seconds))) {
+      eventually(RichMatchers.timeout(Span(10, Seconds))) {
         val res = controller.submit()(fakeRequest)
         status(res) mustBe Status.SEE_OTHER
         res.value.get.get.header.headers("Location") mustBe "/pay-what-you-owe-in-instalments/arrangement/summary"

--- a/test/testsupport/testdata/TdAll.scala
+++ b/test/testsupport/testdata/TdAll.scala
@@ -126,8 +126,6 @@ todays date: 2019-11-25
 
   val unactivatedSaEnrolment: Enrolment = saEnrolment.copy(state = "Not Activated")
 
-  val selectedRegularPaymentAmount300 = 300
-
   val defaultRemainingIncomeAfterSpending: BigDecimal = BigDecimal(1000)
   val netIncomeTooSmallForPlan = 50
   val netIncomeLargeEnoughForSingleDefaultPlan = 12500

--- a/test/testsupport/testdata/TestJourney.scala
+++ b/test/testsupport/testdata/TestJourney.scala
@@ -18,13 +18,11 @@ package testsupport.testdata
 
 import journey.{Journey, JourneyId, PaymentToday, PaymentTodayAmount}
 import journey.Statuses.InProgress
-
 import model.enumsforforms.TypesOfBankAccount.Personal
 import model.enumsforforms.TypesOfBankAccount
 import ssttpaffordability.model.Expense.HousingExp
 import ssttpaffordability.model.IncomeCategory.MonthlyIncome
 import ssttpaffordability.model.{Expenses, Income, IncomeBudgetLine, Spending}
-import testsupport.testdata.TdAll.selectedRegularPaymentAmount300
 import uk.gov.hmrc.selfservicetimetopay.models.{BankDetails, EligibilityStatus, PaymentDayOfMonth, PlanSelection, SelectedPlan, TypeOfAccountDetails}
 
 import java.time.LocalDateTime
@@ -43,7 +41,7 @@ object TestJourney {
       maybePaymentTodayAmount   = Some(PaymentTodayAmount(200)),
       maybeIncome               = Some(Income(IncomeBudgetLine(MonthlyIncome, 2000))),
       maybeSpending             = Some(Spending(Expenses(HousingExp, 500))),
-      maybePlanSelection        = Some(PlanSelection(Left(SelectedPlan(selectedRegularPaymentAmount300)))),
+      maybePlanSelection        = Some(PlanSelection(Left(SelectedPlan(470)))),
       maybePaymentDayOfMonth    = Some(PaymentDayOfMonth(3)),
       maybeEligibilityStatus    = Some(EligibilityStatus(Seq.empty))
     )


### PR DESCRIPTION
+ refactor 'check your payment plan' and 'view your payment plan' test suites to avoid repetition across two calculator types